### PR TITLE
Add rm parameter to build

### DIFF
--- a/src/Docker/Docker.php
+++ b/src/Docker/Docker.php
@@ -67,20 +67,22 @@ class Docker
     }
 
     /**
-     * @param Docker\Context\Context    $context
-     * @param string                    $name
-     * @param boolean                   $quiet
-     *
+     * Build an image with docker given a specific Context
+     * 
+     * @param Docker\Context\Context    $context  Context sent to docker
+     * @param string                    $name     Will be the name of the image
+     * @param boolean                   $quiet    Remove command output (but not step output)
+     * @param boolean                   $rm       Remove intermediate container during build
+     * 
      * @return Guzzle\Stream\StreamInterface
-     *
-     * The `q` argument seems to be ignored right now (same behavior observed in the CLI client)
      */
-    public function build(Context $context, $name, $quiet = false, $cache = true)
+    public function build(Context $context, $name, $quiet = false, $cache = true, $rm = false)
     {
         $request = $this->client->post(['/build{?data*}', ['data' => [
             'q' => (integer) $quiet,
             't' => $name,
             'nocache' => (integer) !$cache,
+            'rm' => (integer) $rm
         ]]], [
             'Content-Type' => 'application/tar'
         ]);


### PR DESCRIPTION
Even if it's not in the documentation a rm parameter can be passed to suppress intermediate container as you can see here :

https://github.com/dotcloud/docker/blob/20f36f088c86569d59c8cfe27a99742f31f4fbd3/commands.go#L165

There is also a remote parameter which may be interesting to add in the future (but for now i don't know the purpose of this parameter)

I also remove the warning about q argument as it's no longer true (q suppress verbose of command run, but not build output)
