### PR TITLE
Set context and http client to work with stream to use less memory

### DIFF
--- a/src/Docker/Context/ContextInterface.php
+++ b/src/Docker/Context/ContextInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Docker\Context;
+
+interface ContextInterface
+{
+    /**
+     * Get context as a stream
+     *
+     * return ressource Return a stream ressource
+     */
+    public function toStream();
+}

--- a/src/Docker/Docker.php
+++ b/src/Docker/Docker.php
@@ -7,6 +7,7 @@ use Docker\Http\Client;
 use Docker\Manager\ContainerManager;
 use Docker\Manager\ImageManager;
 use Docker\Exception\UnexpectedStatusCodeException;
+use Docker\Context\ContextInterface;
 
 /**
  * Docker\Docker
@@ -67,15 +68,17 @@ class Docker
     }
 
     /**
-     * @param Docker\Context\Context    $context
-     * @param string                    $name
-     * @param boolean                   $quiet
+     * Build an image with docker
+     *
+     * @param Docker\Context\ContextInterface    $context
+     * @param string                             $name
+     * @param boolean                            $quiet
      *
      * @return Guzzle\Stream\StreamInterface
      *
      * The `q` argument seems to be ignored right now (same behavior observed in the CLI client)
      */
-    public function build(Context $context, $name, $quiet = false, $cache = true)
+    public function build(ContextInterface $context, $name, $quiet = false, $cache = true)
     {
         $request = $this->client->post(['/build{?data*}', ['data' => [
             'q' => (integer) $quiet,
@@ -87,7 +90,7 @@ class Docker
 
         # http client does not support chunked responses yet
         $request->setProtocolVersion('1.1');
-        $request->setContent($context->toTar());
+        $request->setContent($context->toStream(), 'application/tar');
 
         $response = $this->client->send($request);
 

--- a/src/Docker/Http/Response.php
+++ b/src/Docker/Http/Response.php
@@ -133,8 +133,10 @@ class Response
      *
      * @param callable $callback Callback to call, this
      */
-    public function read(callable $callback)
+    public function read(callable $callback = null)
     {
-        return $callback($this->getContent());
+        if (null !== $callback) {
+            $callback($this->getContent());
+        }
     }
 }


### PR DESCRIPTION
Make some changes to not have the tar of context in memory :
- Request now accept a stream for it's content, and specify a Transfer-Encoding chunk in his header if it's the case
- Client detect if the content of request is a stream, in this case it will send the request with transfer-encoding chunked by part of 8192 bytes (8kbytes) 
- ContextInterface has been created which specify that a Context must have a toStream method
- Docker build now accept a ContextInterface and set the content of Request with the toStream method of Context
- Context toStream method now use low level php function to get a stream pipe for getting output of tar command for toStream method (not possible with ProcessComponent of Symfony)

Test pass, but due to the low level in toStream method there may be unexpected bug that we will see in the futur
