### PR TITLE
Try harder to find an exit code

### DIFF
--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -4,6 +4,8 @@ namespace Docker;
 
 use Docker\Exception\PortNotFoundException;
 
+use LogicException;
+
 /**
  * Docker\Container
  */
@@ -184,7 +186,15 @@ class Container
      */
     public function getExitCode()
     {
-        return $this->exitCode;
+        if (null !== $this->exitCode) {
+            return $this->exitCode;
+        }
+
+        if (is_array($this->runtimeInformations)) {
+            return $this->runtimeInformations['State']['ExitCode'];
+        }
+
+        throw new LogicException('Could not find an exit code');
     }
 
     /**


### PR DESCRIPTION
Since the Docker API is a bit messy, `Container#getExitCode` has to look for the exit code in multiple possible places
