### PR TITLE
Added global timeout option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
         "php": ">=5.4",
         "guzzle/parser": "~3.8",
         "symfony/filesystem": "~2.3",
-        "symfony/process": "~2.3",
-        "symfony/options-resolver": "~2.3"
+        "symfony/process": "~2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/src/Docker/Docker.php
+++ b/src/Docker/Docker.php
@@ -9,9 +9,6 @@ use Docker\Manager\ImageManager;
 use Docker\Exception\UnexpectedStatusCodeException;
 use Docker\Context\ContextInterface;
 
-use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-
 /**
  * Docker\Docker
  */
@@ -42,32 +39,9 @@ class Docker
      * @param Docker\Http\Client    $client
      * @param array                 $array
      */
-    public function __construct($options = array(), HttpClient $httpClient = null)
+    public function __construct(HttpClient $httpClient = null)
     {
-        $options = $this
-            ->setDefaultOptions(new OptionsResolver())
-            ->resolve($options);
-
         $this->httpClient = $httpClient ?: new HttpClient('tcp://127.0.0.1:4243');
-        $this->httpClient->setTimeout($options['http_timeout']);
-    }
-
-    /**
-     * @param Symfony\Component\OptionsResolver\OptionsResolverInterface $resolver
-     * 
-     * @return Symfony\Component\OptionsResolver\OptionsResolverInterface
-     */
-    private function setDefaultOptions(OptionsResolverInterface $resolver)
-    {
-        $resolver->setDefaults([
-            'http_timeout' => (integer) ini_get('default_socket_timeout'),
-        ]);
-
-        $resolver->setAllowedTypes([
-            'http_timeout' => 'integer',
-        ]);
-
-        return $resolver;
     }
 
     /**

--- a/src/Docker/Tests/DockerTest.php
+++ b/src/Docker/Tests/DockerTest.php
@@ -15,10 +15,9 @@ class DockerTest extends TestCase
      */
     public function testGlobalHttpTimeout()
     {
-        $docker = new Docker(['http_timeout' => 1], new Client('tcp://127.0.0.1:4243'));
+        $docker = $this->getDocker();
 
-        $this->assertEquals(1, $docker->getHttpClient()->getTimeout());
-
+        $docker->getHttpClient()->setTimeout(1);
         $container = new Container(['Image' => 'ubuntu:precise', 'Cmd' => ['/bin/sleep', '2']]);
 
         $docker->getContainerManager()

--- a/src/Docker/Tests/TestCase.php
+++ b/src/Docker/Tests/TestCase.php
@@ -14,7 +14,7 @@ class TestCase extends PHPUnit_Framework_TestCase
     public function getDocker()
     {
         if (null === $this->docker) {
-            $this->docker = new Docker([], new Client('tcp://127.0.0.1:4243'));
+            $this->docker = new Docker(new Client('tcp://127.0.0.1:4243'));
         }
 
         return $this->docker;


### PR DESCRIPTION
Allow to set a global timeout option, not just for `->wait()` (because sometimes `->commit()` is painfuly slow and timeouts)
