### PR TITLE
Fix hhvm test in travis

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -7,6 +7,9 @@ phpenv rehash 2>/dev/null
 # Exit on first error
 set -e
 
+# Mount rount
+mount -t tmpfs none /root
+
 # Kill background processes on exit
 trap 'kill $(jobs -p)' SIGINT SIGTERM EXIT
 


### PR DESCRIPTION
Problem was : hhvm create a database for the JIT, but since we run in a read only environnement, we cannot write.

I add a memory file system mount (tmpfs) for /root directory so hhvm can create files.
