### PR TITLE
Fix build with a context directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "php": ">=5.4",
         "symfony/filesystem": "~2.3",
         "symfony/process": "~2.3",
-        "guzzlehttp/guzzle": "~4.0"
+        "guzzlehttp/guzzle": "~4.0",
+        "guzzlehttp/streams": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/src/Docker/Docker.php
+++ b/src/Docker/Docker.php
@@ -9,7 +9,7 @@ use Docker\Manager\ImageManager;
 use Docker\Exception\UnexpectedStatusCodeException;
 use Docker\Context\ContextInterface;
 use GuzzleHttp\Client as HttpClient;
-use GuzzleHttp\Stream;
+use GuzzleHttp\Stream\Stream;
 
 /**
  * Docker\Docker

--- a/src/Docker/Tests/DockerTest.php
+++ b/src/Docker/Tests/DockerTest.php
@@ -3,7 +3,7 @@
 namespace Docker\Tests;
 
 use Docker\Docker;
-use Docker\Context;
+use Docker\Context\Context;
 use Docker\Container;
 use Docker\Context\ContextBuilder;
 use Docker\Http\Client;
@@ -23,6 +23,26 @@ class DockerTest extends TestCase
         });
 
         $this->assertRegExp('/Successfully built/', $content);
+    }
+
+    public function testBuildWithExistingDirectory()
+    {
+        if (!file_exists('/bin/tar')) {
+            $this->markTestSkipped('No /bin/tar on host');
+        }
+
+        $docker     = $this->getDocker();
+        $directory  = __DIR__.DIRECTORY_SEPARATOR."Context".DIRECTORY_SEPARATOR."context-test";
+        $context    = new Context($directory);
+        $timecalled = 0;
+
+        $docker->build($context, 'foo', function($output, $type) use(&$content, &$timecalled) {
+            $content .= $output;
+            $timecalled++;
+        });
+
+        $this->assertRegExp('/Successfully built/', $content);
+        $this->assertGreaterThan(1, $timecalled);
     }
 
     public function testCommit()


### PR DESCRIPTION
There are some problems when building with a Context build from a directory.
- Need to set guzzlehttp/streams to last version, to fix a Notice problem
- Fix a namespace problem
- Docker can send a 100 Continue response when sending a request with chunked transfer encoding, i had a way to handle it
- Add tests for this case
