### PR TITLE
fixes #41 - warning when connexion cannot be opened

### DIFF
--- a/src/Docker/Http/Adapter/DockerAdapter.php
+++ b/src/Docker/Http/Adapter/DockerAdapter.php
@@ -71,7 +71,10 @@ class DockerAdapter implements  AdapterInterface
             $request->setHeader('Content-Length', $request->getBody()->getSize());
         }
 
-        $socket = stream_socket_client($this->entrypoint, $errorNo, $errorMsg, $this->getDefaultTimeout($transaction));
+        $socket = @stream_socket_client($this->entrypoint, $errorNo, $errorMsg, $this->getDefaultTimeout($transaction));
+        if(!$socket) {
+            throw new RequestException(sprintf('Cannot open socket connection: %s [code %d]', $errorMsg, $errorNo), $request);
+        }
 
         // Write headers
         fwrite($socket, $this->getRequestHeaderAsString($request));


### PR DESCRIPTION
I think that's not a problem to use the error control operator (`@`) here, since we handle the warning just after.  We don't hide warning, we strengthens it. 
