### PR TITLE
Fixed container name regex to match Docker Remote API spec

### DIFF
--- a/src/Docker/Container.php
+++ b/src/Docker/Container.php
@@ -193,7 +193,9 @@ class Container
      */
     public function setName($name)
     {
-        if (!preg_match("/^([a-zA-Z0-9_-]+\/)?[a-zA-Z0-9_-]+$/", $name)) { throw new \Exception("Name was not correctly formatted.", 1); }
+        if (!preg_match("/^\/?[a-zA-Z0-9_-]+$/", $name)) {
+            throw new \Exception("Name was not correctly formatted.", 1);
+        }
 
         $this->name = $name;
 

--- a/src/Docker/Tests/ContainerTest.php
+++ b/src/Docker/Tests/ContainerTest.php
@@ -34,8 +34,8 @@ class ContainerTest extends PHPUnit_Framework_TestCase
     public function testValidContainerName()
     {
         $container = new Container();
-        $container->setName('Foo/Bar');
-        $this->assertEquals('Foo/Bar', $container->getName());
+        $container->setName('/Foobar');
+        $this->assertEquals('/Foobar', $container->getName());
     }
 
     public function testInvalidContainerNameOne()


### PR DESCRIPTION
The previous container name validation was for a valid image name, not a container name. This patch matches the pattern to what the Docker daemon expects. See the docs for /containers/create here: https://docs.docker.com/reference/api/docker_remote_api_v1.13/#21-containers

> -   **name** – Assign the specified name to the container. Must
>   match `/?[a-zA-Z0-9_-]+`.
