### PR TITLE
Fixed extra request issue in ContainerManager::stop

### DIFF
--- a/src/Docker/Manager/ContainerManager.php
+++ b/src/Docker/Manager/ContainerManager.php
@@ -278,12 +278,10 @@ class ContainerManager
      */
     public function stop(Container $container, $timeout = 5)
     {
-        $request = $this->client->post(['/containers/{id}/stop?t={timeout}', [
+        $response = $this->client->post(['/containers/{id}/stop?t={timeout}', [
             'id' => $container->getId(),
             'timeout' => $timeout
         ]]);
-
-        $response = $this->client->send($request);
 
         if ($response->getStatusCode() !== "204") {
             throw UnexpectedStatusCodeException::fromResponse($response);


### PR DESCRIPTION
The logic here was trying to send the response of the initial request as a second request. Seems to have snuck in there because a variable was incorrectly named.
