### PR TITLE
Use a stream filter for chunk encoding

### DIFF
--- a/src/Docker/Http/DockerClient.php
+++ b/src/Docker/Http/DockerClient.php
@@ -27,4 +27,4 @@ class DockerClient extends Client
 
         parent::__construct($config);
     }
-} 
+}

--- a/src/Docker/Http/Stream/Filter/Chunk.php
+++ b/src/Docker/Http/Stream/Filter/Chunk.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Docker\Http\Stream\Filter;
+
+class Chunk extends \php_user_filter
+{
+    public function filter($in, $out, &$consumed, $closing)
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            $lenbucket = stream_bucket_new($this->stream,  dechex($bucket->datalen)."\r\n");
+            stream_bucket_append($out, $lenbucket);
+
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+
+            $lenbucket = stream_bucket_new($this->stream, "\r\n");
+            stream_bucket_append($out, $lenbucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+} 

--- a/src/Docker/Tests/Context/ContextTest.php
+++ b/src/Docker/Tests/Context/ContextTest.php
@@ -10,25 +10,17 @@ class ContextTest extends TestCase
 {
     public function testReturnsValidTarContent()
     {
-        if (!file_exists('/bin/tar')) {
-            $this->markTestSkipped('No /bin/tar on host');
-        }
-
         $directory = __DIR__.DIRECTORY_SEPARATOR."context-test";
 
         $context = new Context($directory);
-        $process = new Process('/bin/tar c .', $directory);
+        $process = new Process('/usr/bin/env tar c .', $directory);
         $process->run();
 
-        $this->assertEquals(md5($process->getOutput()), md5($context->toTar()));
+        $this->assertEquals(strlen($process->getOutput()), strlen($context->toTar()));
     }
 
     public function testReturnsValidTarStream()
     {
-        if (!file_exists('/bin/tar')) {
-            $this->markTestSkipped('No /bin/tar on host');
-        }
-
         $directory = __DIR__.DIRECTORY_SEPARATOR."context-test";
 
         $context = new Context($directory);

--- a/src/Docker/Tests/DockerTest.php
+++ b/src/Docker/Tests/DockerTest.php
@@ -27,10 +27,6 @@ class DockerTest extends TestCase
 
     public function testBuildWithExistingDirectory()
     {
-        if (!file_exists('/bin/tar')) {
-            $this->markTestSkipped('No /bin/tar on host');
-        }
-
         $docker     = $this->getDocker();
         $directory  = __DIR__.DIRECTORY_SEPARATOR."Context".DIRECTORY_SEPARATOR."context-test";
         $context    = new Context($directory);


### PR DESCRIPTION
This allow to be more decoupled in the Docker Adapter and also is a POC for a new way of dealing with callback.

This also fix some rare conditions where length of chunk was not correct and was causing a broken pipe, length is now directly get from php so it should be correct.

I'm currently thinking on using filter also when reading for the callback use, so we will be able to apply multiple callback / filter on the stream and have a more generic interface.

Let met know what you think /cc @ubermuda 
