### PR TITLE
Feature docker getversion

### DIFF
--- a/src/Docker/Docker.php
+++ b/src/Docker/Docker.php
@@ -78,6 +78,7 @@ class Docker
     }
 
    /**
+     * Show the docker components version information
      * @return json object with version values
      */
     public function getVersion()
@@ -89,6 +90,22 @@ class Docker
         }
         return $response->json();
     }
+
+   /**
+     * Docker info: Display system-wide information
+     * api_v1.16
+     * @return json object with version values
+     */
+    public function getInfo()
+    {
+        try {
+            $response = $this->httpClient->get(['/info', []]);
+        } catch (RequestException $e) {
+            throw $e;
+        }
+        return $response->json();
+    }
+
 
     /**
      * Build an image with docker


### PR DESCRIPTION
Small (low prio) function to query the docker version info, return something like this:
(
    [ApiVersion] => 1.15
    [Arch] => amd64
    [GitCommit] => 4e9bbfa
    [GoVersion] => go1.3.3
    [KernelVersion] => 3.13.0-39-generic
    [Os] => linux
    [Version] => 1.3.1
)
One could stpore the api version in the docker object and use it for compatibility decisions later. e.g. give an err if the api is less that a version tested with docker-php
