### PR TITLE
Fix method of /exec/(id)/json call

### DIFF
--- a/docker-swagger.json
+++ b/docker-swagger.json
@@ -3299,7 +3299,7 @@
       }
     },
     "/exec/{id}/json": {
-      "post": {
+      "get": {
         "summary": "Exec Inspect",
         "description": "Return low-level information about the exec command id.",
         "operationId": "find",

--- a/generated/Resource/ExecResource.php
+++ b/generated/Resource/ExecResource.php
@@ -119,7 +119,7 @@ class ExecResource extends Resource
         $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
         $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
         $body       = $queryParam->buildFormDataString($parameters);
-        $request    = $this->messageFactory->createRequest('POST', $url, $headers, $body);
+        $request    = $this->messageFactory->createRequest('GET', $url, $headers, $body);
         $response   = $this->httpClient->sendRequest($request);
         if (self::FETCH_OBJECT == $fetch) {
             if ('200' == $response->getStatusCode()) {

--- a/tests/Manager/ExecManagerTest.php
+++ b/tests/Manager/ExecManagerTest.php
@@ -53,6 +53,30 @@ class ExecManagerTest extends TestCase
         ]);
     }
 
+    public function testExecFind()
+    {
+        $createContainerResult = $this->createContainer();
+
+        $execConfig = new ExecConfig();
+        $execConfig->setCmd(["/bin/true"]);
+
+        $execCreateResult = $this->getManager()->create($createContainerResult->getId(), $execConfig);
+
+        $execStartConfig = new ExecStartConfig();
+        $execStartConfig->setDetach(false);
+        $execStartConfig->setTty(false);
+
+        $this->getManager()->start($execCreateResult->getId(), $execStartConfig);
+
+        $execFindResult = $this->getManager()->find($execCreateResult->getId());
+
+        $this->assertInstanceOf('Docker\API\Model\ExecCommand', $execFindResult);
+
+        self::getDocker()->getContainerManager()->kill($createContainerResult->getId(), [
+            'signal' => 'SIGKILL'
+        ]);
+    }
+
     private function createContainer()
     {
         $containerConfig = new ContainerConfig();


### PR DESCRIPTION
ExecManager::find() shoud perform a GET request to /exec/(id)/json. It currently performs a POST request.