### PR TITLE
Adjust options when DOCKER_TLS_VERIFY is enabled

### DIFF
--- a/src/DockerClient.php
+++ b/src/DockerClient.php
@@ -72,13 +72,20 @@ class DockerClient implements HttpClient
             $cafile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'ca.pem';
             $certfile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'cert.pem';
             $keyfile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'key.pem';
-            $peername = getenv('DOCKER_PEER_NAME') ? getenv('DOCKER_PEER_NAME') : 'boot2docker';
 
-            $options['ssl'] = [
-                'cafile' => $cafile,
-                'local_cert' => $certfile,
-                'local_pk' => $keyfile,
-                'peer_name' => $peername,
+            $stream_context = [
+                'cafile'        => $cafile,
+                'local_cert'    => $certfile,
+                'local_pk'      => $keyfile,
+            ];
+
+            if (getenv('DOCKER_PEER_NAME')) {
+                $stream_context['peer_name'] = getenv('DOCKER_PEER_NAME');
+            }
+
+            $options['ssl'] = true;
+            $options['stream_context_options'] = [
+                'ssl' =>  $stream_context
             ];
         }
 


### PR DESCRIPTION
@joelwurtz , can you look into this?

The DockerClient::createFromEnv not producing correct connection param.


Current output is:
```
Array
(
    [remote_socket] => tcp://192.168.99.100:2376
    [ssl] => Array
        (
            [cafile] => /Users/smacalalag/.docker/machine/machines/default/ca.pem
            [local_cert] => /Users/smacalalag/.docker/machine/machines/default/cert.pem
            [local_pk] => /Users/smacalalag/.docker/machine/machines/default/key.pem
            [peer_name] => boot2docker
        )

)
```

Should be:

```
Array
(
    [remote_socket] => tcp://192.168.99.100:2376
    [ssl] => 1
    [stream_context_options] => Array
        (
            [ssl] => Array
                (
                    [cafile] => /Users/smacalalag/.docker/machine/machines/default/ca.pem
                    [local_cert] => /Users/smacalalag/.docker/machine/machines/default/cert.pem
                    [local_pk] => /Users/smacalalag/.docker/machine/machines/default/key.pem
                    [peer_name] => boot2docker
                )

        )

)
```

Also, If peer_name is not set, then the name is guessed based on the hostname used when opening the stream. So, I made changes on how the peer_name should be added.