### PR TITLE
Null value support to array properties

### DIFF
--- a/docker-swagger.json
+++ b/docker-swagger.json
@@ -151,13 +151,13 @@
       "type": "object",
       "properties": {
         "Binds": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "Links": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -192,31 +192,31 @@
           "type": "integer"
         },
         "BlkioWeightDevice": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/DeviceWeight"
           }
         },
         "BlkioDeviceReadBps": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/DeviceRate"
           }
         },
         "BlkioDeviceReadIOps": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/DeviceRate"
           }
         },
         "BlkioDeviceWriteBps": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/DeviceRate"
           }
         },
         "BlkioDeviceWriteIOps": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/DeviceRate"
           }
@@ -243,37 +243,37 @@
           "type": "boolean"
         },
         "Dns": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "DnsSearch": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "ExtraHosts": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "VolumesFrom": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "CapAdd": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "CapDrop": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -285,19 +285,19 @@
           "type": "string"
         },
         "Devices": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/Device"
           }
         },
         "Ulimits": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/Ulimit"
           }
         },
         "SecurityOpt": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -339,7 +339,7 @@
           "type": "string"
         },
         "Names": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -360,7 +360,7 @@
           "type": "string"
         },
         "Ports": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/port"
           }
@@ -411,7 +411,7 @@
           "default": false
         },
         "Env": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -429,7 +429,7 @@
           }
         },
         "Mounts": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/mount"
           }
@@ -568,7 +568,7 @@
           "type": "string"
         },
         "Args": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -631,7 +631,7 @@
           "$ref": "#/definitions/ContainerState"
         },
         "Mounts": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/mount"
           }
@@ -642,15 +642,15 @@
       "type": "object",
       "properties": {
         "Titles": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "Processes": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
               "type": "string"
             }
@@ -692,7 +692,7 @@
       "type": "object",
       "properties": {
         "RepoTags": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -713,13 +713,13 @@
           "type": "integer"
         },
         "Labels": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": {
             "type": "string"
           }
         },
         "RepoDigests": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -769,13 +769,13 @@
           "$ref": "#/definitions/GraphDriver"
         },
         "RepoDigests": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
         },
         "RepoTags": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -798,7 +798,7 @@
           "type": "string"
         },
         "Tags": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -888,18 +888,18 @@
           "type": "string"
         },
         "DriverStatus": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
               "type": "string"
             }
           }
         },
         "SystemStatus": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
               "type": "string"
             }
@@ -939,7 +939,7 @@
           "type": "string"
         },
         "Labels": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -1001,7 +1001,7 @@
           }
         },
         "InsecureRegistryCIDRs": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -1012,7 +1012,7 @@
       "type": "object",
       "properties": {
         "Mirrors": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -1066,7 +1066,7 @@
           "type": "boolean"
         },
         "Cmd": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -1129,7 +1129,7 @@
           "type": "string"
         },
         "arguments": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "type": "string"
           }
@@ -1140,7 +1140,7 @@
       "type": "object",
       "properties": {
         "Volumes": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/Volume"
           }
@@ -1217,7 +1217,7 @@
           "type": "string"
         },
         "Config": {
-          "type": "array",
+          "type": ["array", "null"],
           "items": {
             "$ref": "#/definitions/IPAMConfig"
           }


### PR DESCRIPTION
Adding null value support to array properties to stop invalid argument passed to foreach error.

If you're happy with the changes, ./generate.sh would need to be run to update the generated files that contain the issue (#186). I have not done this myself as I'm not familiar with jane-openapi.