### PR TITLE
Added missing Content-Type header for volume creation

### DIFF
--- a/docker-swagger.json
+++ b/docker-swagger.json
@@ -3482,6 +3482,13 @@
           "schema": {
             "$ref": "#/definitions/VolumeConfig"
           }
+        }, {
+          "name": "Content-Type",
+          "required": true,
+          "in": "header",
+          "type": "string",
+          "default": "application/json",
+          "description": "Content Type of input"
         }],
         "tags": [
           "Volume"

--- a/generated/Resource/VolumeResource.php
+++ b/generated/Resource/VolumeResource.php
@@ -42,7 +42,10 @@ class VolumeResource extends Resource
      * Create a volume.
      *
      * @param \Docker\API\Model\VolumeConfig $volumeConfig Volume configuration
-     * @param array                          $parameters   List of parameters
+     * @param array                          $parameters {
+     *
+     *     @var string $Content-Type Content Type of input
+     * }
      * @param string                         $fetch        Fetch mode (object or response)
      *
      * @return \Psr\Http\Message\ResponseInterface|\Docker\API\Model\Volume
@@ -50,6 +53,8 @@ class VolumeResource extends Resource
     public function create(\Docker\API\Model\VolumeConfig $volumeConfig, $parameters = [], $fetch = self::FETCH_OBJECT)
     {
         $queryParam = new QueryParam();
+        $queryParam->setDefault('Content-Type', 'application/json');
+        $queryParam->setHeaderParameters(['Content-Type']);
         $url        = '/volumes/create';
         $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
         $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));


### PR DESCRIPTION
The "Content-Type" header must be set to "application/json" otherwise it doesn't work.