### PR TITLE
Allow ExposedPorts to be null in ContainerConfig

### DIFF
--- a/docker-swagger.json
+++ b/docker-swagger.json
@@ -486,7 +486,7 @@
           "type": "string"
         },
         "ExposedPorts": {
-          "type": "object",
+          "type": ["object","null"],
           "additionalProperties": {
             "type": "object",
             "enum": [{}],

--- a/generated/Model/ContainerConfig.php
+++ b/generated/Model/ContainerConfig.php
@@ -117,7 +117,7 @@ class ContainerConfig
      */
     protected $macAddress;
     /**
-     * @var mixed[]
+     * @var mixed[]|null
      */
     protected $exposedPorts;
     /**
@@ -690,7 +690,7 @@ class ContainerConfig
     }
 
     /**
-     * @return mixed[]
+     * @return mixed[]|null
      */
     public function getExposedPorts()
     {
@@ -698,11 +698,11 @@ class ContainerConfig
     }
 
     /**
-     * @param mixed[] $exposedPorts
+     * @param mixed[]|null $exposedPorts
      *
      * @return self
      */
-    public function setExposedPorts(\ArrayObject $exposedPorts = null)
+    public function setExposedPorts($exposedPorts = null)
     {
         $this->exposedPorts = $exposedPorts;
 

--- a/generated/Normalizer/ContainerConfigNormalizer.php
+++ b/generated/Normalizer/ContainerConfigNormalizer.php
@@ -194,11 +194,18 @@ class ContainerConfigNormalizer extends SerializerAwareNormalizer implements Den
             $object->setMacAddress($data->{'MacAddress'});
         }
         if (property_exists($data, 'ExposedPorts')) {
-            $values_7 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
-            foreach ($data->{'ExposedPorts'} as $key_1 => $value_13) {
-                $values_7[$key_1] = $value_13;
+            $value_13 = $data->{'ExposedPorts'};
+            if (is_object($data->{'ExposedPorts'})) {
+                $values_7 = new \ArrayObject([], \ArrayObject::ARRAY_AS_PROPS);
+                foreach ($data->{'ExposedPorts'} as $key_1 => $value_14) {
+                    $values_7[$key_1] = $value_14;
+                }
+                $value_13 = $values_7;
             }
-            $object->setExposedPorts($values_7);
+            if (is_null($data->{'ExposedPorts'})) {
+                $value_13 = $data->{'ExposedPorts'};
+            }
+            $object->setExposedPorts($value_13);
         }
         if (property_exists($data, 'NetworkSettings')) {
             $object->setNetworkSettings($this->serializer->deserialize($data->{'NetworkSettings'}, 'Docker\\API\\Model\\NetworkConfig', 'raw', $context));
@@ -359,13 +366,18 @@ class ContainerConfigNormalizer extends SerializerAwareNormalizer implements Den
         if (null !== $object->getMacAddress()) {
             $data->{'MacAddress'} = $object->getMacAddress();
         }
-        if (null !== $object->getExposedPorts()) {
+        $value_13 = $object->getExposedPorts();
+        if (is_object($object->getExposedPorts())) {
             $values_7 = new \stdClass();
-            foreach ($object->getExposedPorts() as $key_1 => $value_13) {
-                $values_7->{$key_1} = $value_13;
+            foreach ($object->getExposedPorts() as $key_1 => $value_14) {
+                $values_7->{$key_1} = $value_14;
             }
-            $data->{'ExposedPorts'} = $values_7;
+            $value_13 = $values_7;
         }
+        if (is_null($object->getExposedPorts())) {
+            $value_13 = $object->getExposedPorts();
+        }
+        $data->{'ExposedPorts'} = $value_13;
         if (null !== $object->getNetworkSettings()) {
             $data->{'NetworkSettings'} = $this->serializer->serialize($object->getNetworkSettings(), 'raw', $context);
         }


### PR DESCRIPTION
This patch allows for the ExposedPorts in ContainerConfig to be null - when no ports are exposed in the container

fixes #206