### PR TITLE
Removing deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.4",
         "symfony/filesystem": "^2.3 || ^3.0",
         "symfony/process": "^2.3 || ^3.0",
-        "jane/open-api": "^1.0",
+        "jane/open-api": "^1.2",
         "php-http/socket-client": "^1.0",
         "php-http/client-common": "^1.1",
         "php-http/message": "^1.0",

--- a/generated/Resource/ContainerResource.php
+++ b/generated/Resource/ContainerResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class ContainerResource extends Resource

--- a/generated/Resource/ExecResource.php
+++ b/generated/Resource/ExecResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class ExecResource extends Resource

--- a/generated/Resource/ImageResource.php
+++ b/generated/Resource/ImageResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class ImageResource extends Resource

--- a/generated/Resource/MiscResource.php
+++ b/generated/Resource/MiscResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class MiscResource extends Resource

--- a/generated/Resource/NetworkResource.php
+++ b/generated/Resource/NetworkResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class NetworkResource extends Resource

--- a/generated/Resource/NodeResource.php
+++ b/generated/Resource/NodeResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class NodeResource extends Resource

--- a/generated/Resource/ServiceResource.php
+++ b/generated/Resource/ServiceResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class ServiceResource extends Resource

--- a/generated/Resource/SwarmResource.php
+++ b/generated/Resource/SwarmResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class SwarmResource extends Resource

--- a/generated/Resource/TaskResource.php
+++ b/generated/Resource/TaskResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class TaskResource extends Resource

--- a/generated/Resource/VolumeResource.php
+++ b/generated/Resource/VolumeResource.php
@@ -2,7 +2,7 @@
 
 namespace Docker\API\Resource;
 
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Client\Resource;
 
 class VolumeResource extends Resource

--- a/src/Manager/ContainerManager.php
+++ b/src/Manager/ContainerManager.php
@@ -4,9 +4,8 @@ namespace Docker\Manager;
 
 use Docker\API\Resource\ContainerResource;
 use Docker\Stream\AttachWebsocketStream;
-use Docker\Stream\DockerRawStaticStream;
 use Docker\Stream\DockerRawStream;
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 
 class ContainerManager extends ContainerResource
 {

--- a/src/Manager/ImageManager.php
+++ b/src/Manager/ImageManager.php
@@ -11,7 +11,7 @@ use Docker\Stream\BuildStream;
 use Docker\Stream\CreateImageStream;
 use Docker\Stream\PushStream;
 use Docker\Stream\TarStream;
-use Joli\Jane\OpenApi\Client\QueryParam;
+use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Psr\Http\Message\StreamInterface;
 
 class ImageManager extends ImageResource


### PR DESCRIPTION
Removing Joli\Jane\OpenApi\Client\QueryParam uses to use Joli\Jane\OpenApi\Runtime\Client\QueryParam.