### PR TITLE
PHP cs-fixer setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 bin/
 composer.lock
 .vagrant
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,38 @@
+<?php
+
+$finder = \PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->notPath('/fixtures/')
+;
+
+return \PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        '@PHP56Migration' => true,
+        '@PHP56Migration:risky' => true,
+        '@PHP70Migration' => true,
+        '@PHP70Migration:risky' => true,
+        '@PHP71Migration' => true,
+        '@PHP71Migration:risky' => true,
+        'array_syntax' => [
+            'syntax' => 'short'
+        ],
+        'combine_consecutive_unsets' => true,
+        'declare_strict_types' => true,
+        'linebreak_after_opening_tag' => true,
+        'modernize_types_casting' => true,
+        'native_function_invocation' => true,
+        'no_php4_constructor' => true,
+        'ordered_imports' => true,
+        'php_unit_strict' => true,
+        'phpdoc_order' => true,
+        'strict_comparison' => true,
+        'strict_param' => true,
+    ])
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
       services:
           - docker
       env: DOCKER_API_VERSION=V1_25 DOCKER_VERSION=17.03.2~ce-0~ubuntu-trusty COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
+    - php: 7.1
+      env: DOCKER_VERSION=17.10.0~ce-0~ubuntu TEST_COMMAND="composer lint"
     - php: 7.2
       sudo: required
       services:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,9 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-ci": "vendor/bin/phpunit --coverage-clover build/coverage.xml"
+        "test-ci": "vendor/bin/phpunit --coverage-clover build/coverage.xml",
+        "lint": "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",
+        "lint-fix": "vendor/bin/php-cs-fixer fix --verbose"
     },
     "extra": {
         "branch-alias": {

--- a/src/Amp/FixedSocketPool.php
+++ b/src/Amp/FixedSocketPool.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Amp;
 
 use Amp\CancellationToken;
@@ -16,7 +18,7 @@ class FixedSocketPool implements SocketPool
 
     public function __construct(string $uri, SocketPool $socketPool = null)
     {
-        if ($socketPool === null) {
+        if (null === $socketPool) {
             $socketPool = new BasicSocketPool();
         }
 
@@ -29,12 +31,12 @@ class FixedSocketPool implements SocketPool
         return $this->socketPool->checkout($this->uri, $token);
     }
 
-    public function checkin(ClientSocket $socket)
+    public function checkin(ClientSocket $socket): void
     {
         $this->socketPool->checkin($socket);
     }
 
-    public function clear(ClientSocket $socket)
+    public function clear(ClientSocket $socket): void
     {
         $this->socketPool->clear($socket);
     }

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -1,18 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Context;
 
-use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
 
 /**
- * Docker\Context\Context
+ * Docker\Context\Context.
  */
 class Context implements ContextInterface
 {
-    const FORMAT_STREAM = 'stream';
+    public const FORMAT_STREAM = 'stream';
 
-    const FORMAT_TAR = 'tar';
+    public const FORMAT_TAR = 'tar';
 
     /**
      * @var string
@@ -35,8 +37,8 @@ class Context implements ContextInterface
     private $format = self::FORMAT_STREAM;
 
     /**
-     * @param string     $directory Directory of context
-     * @param string     $format    Format to use when sending the call (stream or tar: string)
+     * @param string $directory Directory of context
+     * @param string $format    Format to use when sending the call (stream or tar: string)
      */
     public function __construct($directory, $format = self::FORMAT_STREAM)
     {
@@ -45,7 +47,7 @@ class Context implements ContextInterface
     }
 
     /**
-     * Get directory of Context
+     * Get directory of Context.
      *
      * @return string
      */
@@ -55,31 +57,31 @@ class Context implements ContextInterface
     }
 
     /**
-     * Set directory of Context
+     * Set directory of Context.
      *
      * @param string $directory Targeted directory
      */
-    public function setDirectory($directory)
+    public function setDirectory($directory): void
     {
         $this->directory = $directory;
     }
 
     /**
-     * Return content of Dockerfile of this context
+     * Return content of Dockerfile of this context.
      *
      * @return string Content of dockerfile
      */
     public function getDockerfileContent()
     {
-        return file_get_contents($this->directory.DIRECTORY_SEPARATOR.'Dockerfile');
+        return \file_get_contents($this->directory.DIRECTORY_SEPARATOR.'Dockerfile');
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isStreamed()
     {
-        return $this->format === self::FORMAT_STREAM;
+        return self::FORMAT_STREAM === $this->format;
     }
 
     /**
@@ -91,7 +93,7 @@ class Context implements ContextInterface
     }
 
     /**
-     * Return the context as a tar archive
+     * Return the context as a tar archive.
      *
      * @throws \Symfony\Component\Process\Exception\ProcessFailedException
      *
@@ -110,15 +112,15 @@ class Context implements ContextInterface
     }
 
     /**
-     * Return a stream for this context
+     * Return a stream for this context.
      *
      * @return resource Stream resource in memory
      */
     public function toStream()
     {
-        if (!is_resource($this->process)) {
-            $this->process = proc_open("/usr/bin/env tar c .", [["pipe", "r"], ["pipe", "w"], ["pipe", "w"]], $pipes, $this->directory);
-            $this->stream  = $pipes[1];
+        if (!\is_resource($this->process)) {
+            $this->process = \proc_open('/usr/bin/env tar c .', [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']], $pipes, $this->directory);
+            $this->stream = $pipes[1];
         }
 
         return $this->stream;
@@ -126,12 +128,12 @@ class Context implements ContextInterface
 
     public function __destruct()
     {
-        if (is_resource($this->process)) {
-            proc_close($this->process);
+        if (\is_resource($this->process)) {
+            \proc_close($this->process);
         }
 
-        if (is_resource($this->stream)) {
-            fclose($this->stream);
+        if (\is_resource($this->stream)) {
+            \fclose($this->stream);
         }
     }
 }

--- a/src/Context/ContextBuilder.php
+++ b/src/Context/ContextBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Context;
 
 use Symfony\Component\Filesystem\Filesystem;
@@ -56,7 +58,7 @@ class ContextBuilder
     }
 
     /**
-     * Sets the format of the Context output
+     * Sets the format of the Context output.
      *
      * @param string $format
      *
@@ -70,7 +72,7 @@ class ContextBuilder
     }
 
     /**
-     * Set the FROM instruction of Dockerfile
+     * Set the FROM instruction of Dockerfile.
      *
      * @param string $from From which image we start
      *
@@ -84,7 +86,7 @@ class ContextBuilder
     }
 
     /**
-     * Set the CMD instruction in the Dockerfile
+     * Set the CMD instruction in the Dockerfile.
      *
      * @param string $command Command to execute
      *
@@ -98,7 +100,7 @@ class ContextBuilder
     }
 
     /**
-     * Set the ENTRYPOINT instruction in the Dockerfile
+     * Set the ENTRYPOINT instruction in the Dockerfile.
      *
      * @param string $entrypoint The entrypoint
      *
@@ -112,7 +114,7 @@ class ContextBuilder
     }
 
     /**
-     * Add a ADD instruction to Dockerfile
+     * Add a ADD instruction to Dockerfile.
      *
      * @param string $path    Path wanted on the image
      * @param string $content Content of file
@@ -127,7 +129,7 @@ class ContextBuilder
     }
 
     /**
-     * Add a RUN instruction to Dockerfile
+     * Add a RUN instruction to Dockerfile.
      *
      * @param string $command Command to run
      *
@@ -141,9 +143,9 @@ class ContextBuilder
     }
 
     /**
-     * Add a ENV instruction to Dockerfile
+     * Add a ENV instruction to Dockerfile.
      *
-     * @param string $name Name of the environment variable
+     * @param string $name  Name of the environment variable
      * @param string $value Value of the environment variable
      *
      * @return \Docker\Context\ContextBuilder
@@ -156,10 +158,10 @@ class ContextBuilder
     }
 
     /**
-     * Add a COPY instruction to Dockerfile
+     * Add a COPY instruction to Dockerfile.
      *
      * @param string $from Path of folder or file to copy
-     * @param string $to Path of destination
+     * @param string $to   Path of destination
      *
      * @return \Docker\Context\ContextBuilder
      */
@@ -171,7 +173,7 @@ class ContextBuilder
     }
 
     /**
-     * Add a WORKDIR instruction to Dockerfile
+     * Add a WORKDIR instruction to Dockerfile.
      *
      * @param string $workdir Working directory
      *
@@ -185,7 +187,7 @@ class ContextBuilder
     }
 
     /**
-     * Add a EXPOSE instruction to Dockerfile
+     * Add a EXPOSE instruction to Dockerfile.
      *
      * @param int $port Port to expose
      *
@@ -199,7 +201,7 @@ class ContextBuilder
     }
 
     /**
-     * Adds an USER instruction to the Dockerfile
+     * Adds an USER instruction to the Dockerfile.
      *
      * @param string $user User to switch to
      *
@@ -213,7 +215,7 @@ class ContextBuilder
     }
 
     /**
-     * Adds a VOLUME instruction to the Dockerfile
+     * Adds a VOLUME instruction to the Dockerfile.
      *
      * @param string $volume Volume path to add
      *
@@ -227,17 +229,17 @@ class ContextBuilder
     }
 
     /**
-     * Create context given the state of builder
+     * Create context given the state of builder.
      *
      * @return \Docker\Context\Context
      */
     public function getContext()
     {
-        if ($this->directory !== null) {
+        if (null !== $this->directory) {
             $this->cleanDirectory();
         }
 
-        $this->directory = sys_get_temp_dir().'/'.md5($this->from.serialize($this->commands));
+        $this->directory = \sys_get_temp_dir().'/'.\md5($this->from.\serialize($this->commands));
         $this->fs->mkdir($this->directory);
         $this->write($this->directory);
 
@@ -253,13 +255,13 @@ class ContextBuilder
     }
 
     /**
-     * Write docker file and associated files in a directory
+     * Write docker file and associated files in a directory.
      *
      * @param string $directory Target directory
      *
      * @void
      */
-    private function write($directory)
+    private function write($directory): void
     {
         $dockerfile = [];
         $dockerfile[] = 'FROM '.$this->from;
@@ -285,27 +287,27 @@ class ContextBuilder
                     $dockerfile[] = 'EXPOSE '.$command['port'];
                     break;
                 case 'VOLUME':
-                    $dockerfile[] = 'VOLUME ' . $command['volume'];
+                    $dockerfile[] = 'VOLUME '.$command['volume'];
                     break;
                 case 'USER':
-                    $dockerfile[] = 'USER ' . $command['user'];
+                    $dockerfile[] = 'USER '.$command['user'];
                     break;
             }
         }
 
         if (!empty($this->entrypoint)) {
-            $dockerfile[] = 'ENTRYPOINT ' . $this->entrypoint;
+            $dockerfile[] = 'ENTRYPOINT '.$this->entrypoint;
         }
 
         if (!empty($this->command)) {
-            $dockerfile[] = 'CMD ' . $this->command;
+            $dockerfile[] = 'CMD '.$this->command;
         }
 
-        $this->fs->dumpFile($directory.DIRECTORY_SEPARATOR.'Dockerfile', implode(PHP_EOL, $dockerfile));
+        $this->fs->dumpFile($directory.DIRECTORY_SEPARATOR.'Dockerfile', \implode(PHP_EOL, $dockerfile));
     }
 
     /**
-     * Generated a file in a directory
+     * Generated a file in a directory.
      *
      * @param string $directory Targeted directory
      * @param string $content   Content of file
@@ -314,21 +316,21 @@ class ContextBuilder
      */
     private function getFile($directory, $content)
     {
-        $hash = md5($content);
+        $hash = \md5($content);
 
-        if (!array_key_exists($hash, $this->files)) {
-            $file = tempnam($directory, '');
+        if (!\array_key_exists($hash, $this->files)) {
+            $file = \tempnam($directory, '');
             $this->fs->dumpFile($file, $content);
-            $this->files[$hash] = basename($file);
+            $this->files[$hash] = \basename($file);
         }
 
         return $this->files[$hash];
     }
 
     /**
-     * Clean directory generated
+     * Clean directory generated.
      */
-    private function cleanDirectory()
+    private function cleanDirectory(): void
     {
         $this->fs->remove($this->directory);
     }

--- a/src/Context/ContextInterface.php
+++ b/src/Context/ContextInterface.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Context;
 
 /**
- * Docker\Context\ContextInterface
+ * Docker\Context\ContextInterface.
  */
 interface ContextInterface
 {
     /**
      * Whether the Context should be streamed or not.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStreamed();
 

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker;
 
 use Docker\API\Client;
@@ -9,7 +11,7 @@ use Docker\Resource\ImageResourceTrait;
 use Docker\Resource\SystemResourceTrait;
 
 /**
- * Docker\Docker
+ * Docker\Docker.
  */
 class Docker extends Client
 {
@@ -22,7 +24,7 @@ class Docker extends Client
 
     public static function create($httpClient = null)
     {
-        if ($httpClient === null) {
+        if (null === $httpClient) {
             $httpClient = DockerClient::createFromEnv();
         }
 

--- a/src/DockerAsync.php
+++ b/src/DockerAsync.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker;
 
 use Docker\API\ClientAsync;
 
 /**
- * Docker\Docker
+ * Docker\Docker.
  */
 class DockerAsync extends ClientAsync
 {
@@ -13,7 +15,7 @@ class DockerAsync extends ClientAsync
 
     public static function create($httpClient = null)
     {
-        if ($httpClient === null) {
+        if (null === $httpClient) {
             $httpClient = DockerAsyncClient::createFromEnv();
         }
 

--- a/src/DockerAsyncClient.php
+++ b/src/DockerAsyncClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker;
 
 use Amp\Artax\Client;
@@ -27,7 +29,7 @@ class DockerAsyncClient implements Client
     public function request($uriOrRequest, array $options = [], CancellationToken $cancellation = null): Promise
     {
         if ($uriOrRequest instanceof Request) {
-            $uriOrRequest = $uriOrRequest->withUri('http://localhost' . $uriOrRequest->getUri());
+            $uriOrRequest = $uriOrRequest->withUri('http://localhost'.$uriOrRequest->getUri());
         }
 
         return $this->client->request($uriOrRequest, $options, $cancellation);
@@ -42,7 +44,7 @@ class DockerAsyncClient implements Client
         ]);
 
         $resolver->setRequired([
-            'remote_socket'
+            'remote_socket',
         ]);
 
         $resolver->setAllowedTypes('ssl', ['null', ClientTlsContext::class]);
@@ -53,19 +55,19 @@ class DockerAsyncClient implements Client
     public static function createFromEnv(): self
     {
         $options = [
-            'remote_socket' => getenv('DOCKER_HOST') ? getenv('DOCKER_HOST') : 'unix:///var/run/docker.sock'
+            'remote_socket' => \getenv('DOCKER_HOST') ? \getenv('DOCKER_HOST') : 'unix:///var/run/docker.sock',
         ];
 
-        if (getenv('DOCKER_TLS_VERIFY') && getenv('DOCKER_TLS_VERIFY') == 1) {
-            if (!getenv('DOCKER_CERT_PATH')) {
+        if (\getenv('DOCKER_TLS_VERIFY') && 1 === \getenv('DOCKER_TLS_VERIFY')) {
+            if (!\getenv('DOCKER_CERT_PATH')) {
                 throw new \RuntimeException('Connection to docker has been set to use TLS, but no PATH is defined for certificate in DOCKER_CERT_PATH docker environnement variable');
             }
 
             $tlsContext = new ClientTlsContext();
 
-            $cafile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'ca.pem';
-            $certfile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'cert.pem';
-            $keyfile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'key.pem';
+            $cafile = \getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'ca.pem';
+            $certfile = \getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'cert.pem';
+            $keyfile = \getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'key.pem';
 
             $tlsContext = $tlsContext->withCaFile($cafile);
 
@@ -75,8 +77,8 @@ class DockerAsyncClient implements Client
 //                'local_pk'      => $keyfile,
 //            ];
 
-            if (getenv('DOCKER_PEER_NAME')) {
-                $tlsContext = $tlsContext->withPeerName(getenv('DOCKER_PEER_NAME'));
+            if (\getenv('DOCKER_PEER_NAME')) {
+                $tlsContext = $tlsContext->withPeerName(\getenv('DOCKER_PEER_NAME'));
             }
 
             $options['ssl'] = $tlsContext;

--- a/src/DockerClient.php
+++ b/src/DockerClient.php
@@ -1,17 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker;
 
 use GuzzleHttp\Psr7\Uri;
 use Http\Client\Common\Plugin\AddHostPlugin;
 use Http\Client\Common\Plugin\ContentLengthPlugin;
 use Http\Client\Common\Plugin\DecoderPlugin;
-use Http\Client\Common\Plugin\ErrorPlugin;
-use Http\Client\Common\PluginClient;
 use Http\Client\Common\PluginClientFactory;
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Http\Client\Socket\Client as SocketHttpClient;
+use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Psr\Http\Message\RequestInterface;
 
 class DockerClient implements HttpClient
@@ -25,7 +25,7 @@ class DockerClient implements HttpClient
     {
         $messageFactory = new GuzzleMessageFactory();
         $socketClient = new SocketHttpClient($messageFactory, $socketClientOptions);
-        $host = preg_match('/unix:\/\//', $socketClientOptions['remote_socket']) ? 'http://localhost' : $socketClientOptions['remote_socket'];
+        $host = \preg_match('/unix:\/\//', $socketClientOptions['remote_socket']) ? 'http://localhost' : $socketClientOptions['remote_socket'];
 
         $this->httpClient = $pluginClientFactory->createClient($socketClient, [
             new ContentLengthPlugin(),
@@ -35,7 +35,7 @@ class DockerClient implements HttpClient
     }
 
     /**
-     * (@inheritdoc}
+     * (@inheritdoc}.
      */
     public function sendRequest(RequestInterface $request)
     {
@@ -50,46 +50,46 @@ class DockerClient implements HttpClient
         $pluginClientFactory = $pluginClientFactory ?? new PluginClientFactory();
 
         return new self($pluginClientFactory, [
-            'remote_socket' => 'unix:///var/run/docker.sock'
+            'remote_socket' => 'unix:///var/run/docker.sock',
         ]);
     }
 
     /**
-     * Create a docker client from environment variables
-     *
-     * @return DockerClient
+     * Create a docker client from environment variables.
      *
      * @throws \RuntimeException Throw exception when invalid environment variables are given
+     *
+     * @return DockerClient
      */
     public static function createFromEnv(PluginClientFactory $pluginClientFactory = null)
     {
         $pluginClientFactory = $pluginClientFactory ?? new PluginClientFactory();
         $options = [
-            'remote_socket' => getenv('DOCKER_HOST') ? getenv('DOCKER_HOST') : 'unix:///var/run/docker.sock'
+            'remote_socket' => \getenv('DOCKER_HOST') ? \getenv('DOCKER_HOST') : 'unix:///var/run/docker.sock',
         ];
 
-        if (getenv('DOCKER_TLS_VERIFY') && getenv('DOCKER_TLS_VERIFY') == 1) {
-            if (!getenv('DOCKER_CERT_PATH')) {
+        if (\getenv('DOCKER_TLS_VERIFY') && 1 === \getenv('DOCKER_TLS_VERIFY')) {
+            if (!\getenv('DOCKER_CERT_PATH')) {
                 throw new \RuntimeException('Connection to docker has been set to use TLS, but no PATH is defined for certificate in DOCKER_CERT_PATH docker environnement variable');
             }
 
-            $cafile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'ca.pem';
-            $certfile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'cert.pem';
-            $keyfile = getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'key.pem';
+            $cafile = \getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'ca.pem';
+            $certfile = \getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'cert.pem';
+            $keyfile = \getenv('DOCKER_CERT_PATH').DIRECTORY_SEPARATOR.'key.pem';
 
             $stream_context = [
-                'cafile'        => $cafile,
-                'local_cert'    => $certfile,
-                'local_pk'      => $keyfile,
+                'cafile' => $cafile,
+                'local_cert' => $certfile,
+                'local_pk' => $keyfile,
             ];
 
-            if (getenv('DOCKER_PEER_NAME')) {
-                $stream_context['peer_name'] = getenv('DOCKER_PEER_NAME');
+            if (\getenv('DOCKER_PEER_NAME')) {
+                $stream_context['peer_name'] = \getenv('DOCKER_PEER_NAME');
             }
 
             $options['ssl'] = true;
             $options['stream_context_options'] = [
-                'ssl' =>  $stream_context
+                'ssl' => $stream_context,
             ];
         }
 

--- a/src/Resource/ExecResourceTrait.php
+++ b/src/Resource/ExecResourceTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Resource;
 
 use Docker\Docker;
@@ -13,15 +15,15 @@ trait ExecResourceTrait
     {
         $queryParam = new QueryParam();
         $url = '/exec/{id}/start';
-        $url = str_replace('{id}', urlencode($id), $url);
-        $url = $url . ('?' . $queryParam->buildQueryString($parameters));
-        $headers = array_merge(['Host' => 'localhost', 'Content-Type' => 'application/json'], $queryParam->buildHeaders($parameters));
+        $url = \str_replace('{id}', \urlencode($id), $url);
+        $url = $url.('?'.$queryParam->buildQueryString($parameters));
+        $headers = \array_merge(['Host' => 'localhost', 'Content-Type' => 'application/json'], $queryParam->buildHeaders($parameters));
         $body = $this->serializer->serialize($execStartConfig, 'json');
         $request = $this->messageFactory->createRequest('POST', $url, $headers, $body);
         $response = $this->httpClient->sendRequest($request);
 
-        if ($response->getStatusCode() === 200 && DockerRawStream::HEADER === $response->getHeaderLine('Content-Type')) {
-            if ($fetch === Docker::FETCH_STREAM) {
+        if (200 === $response->getStatusCode() && DockerRawStream::HEADER === $response->getHeaderLine('Content-Type')) {
+            if (Docker::FETCH_STREAM === $fetch) {
                 return new DockerRawStream($response->getBody());
             }
         }

--- a/src/Resource/ImageResourceTrait.php
+++ b/src/Resource/ImageResourceTrait.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Resource;
 
+use Docker\API\Resource\ImageResourceTrait as BaseImageResourceTrait;
 use Docker\Stream\BuildStream;
 use Docker\Stream\CreateImageStream;
 use Docker\Stream\PushStream;
 use Docker\Stream\TarStream;
 use Joli\Jane\OpenApi\Runtime\Client\QueryParam;
 use Joli\Jane\OpenApi\Runtime\Client\Resource;
-use Docker\API\Resource\ImageResourceTrait as BaseImageResourceTrait;
 
 trait ImageResourceTrait
 {
@@ -19,7 +21,7 @@ trait ImageResourceTrait
 
     public function imageBuild($inputStream, array $parameters = [], string $fetch = self::FETCH_OBJECT)
     {
-        if (is_resource($inputStream)) {
+        if (\is_resource($inputStream)) {
             $inputStream = new TarStream($inputStream);
         }
 
@@ -34,7 +36,7 @@ trait ImageResourceTrait
                 $buildInfoList = [];
 
                 $stream = new BuildStream($response->getBody(), $this->serializer);
-                $stream->onFrame(function ($buildInfo) use (&$buildInfoList) {
+                $stream->onFrame(function ($buildInfo) use (&$buildInfoList): void {
                     $buildInfoList[] = $buildInfo;
                 });
                 $stream->wait();
@@ -48,8 +50,8 @@ trait ImageResourceTrait
 
     public function imageCreate($inputImage, array $parameters = [], string $fetch = self::FETCH_OBJECT)
     {
-        if (isset($parameters['X-Registry-Auth']) && is_object($parameters['X-Registry-Auth'])) {
-            $parameters['X-Registry-Auth'] = base64_encode($this->serializer->serialize($parameters['X-Registry-Auth'], 'json'));
+        if (isset($parameters['X-Registry-Auth']) && \is_object($parameters['X-Registry-Auth'])) {
+            $parameters['X-Registry-Auth'] = \base64_encode($this->serializer->serialize($parameters['X-Registry-Auth'], 'json'));
         }
 
         $response = $this->imageCreateLegacy($inputImage, $parameters, Resource::FETCH_RESPONSE);
@@ -63,7 +65,7 @@ trait ImageResourceTrait
                 $createImageInfoList = [];
 
                 $stream = new CreateImageStream($response->getBody(), $this->serializer);
-                $stream->onFrame(function ($createImageInfo) use (&$createImageInfoList) {
+                $stream->onFrame(function ($createImageInfo) use (&$createImageInfoList): void {
                     $createImageInfoList[] = $createImageInfo;
                 });
                 $stream->wait();
@@ -77,8 +79,8 @@ trait ImageResourceTrait
 
     public function imagePush(string $name, array $parameters = [], string $fetch = self::FETCH_OBJECT)
     {
-        if (isset($parameters['X-Registry-Auth']) && is_object($parameters['X-Registry-Auth'])) {
-            $parameters['X-Registry-Auth'] = base64_encode($this->serializer->serialize($parameters['X-Registry-Auth'], 'json'));
+        if (isset($parameters['X-Registry-Auth']) && \is_object($parameters['X-Registry-Auth'])) {
+            $parameters['X-Registry-Auth'] = \base64_encode($this->serializer->serialize($parameters['X-Registry-Auth'], 'json'));
         }
 
         $queryParam = new QueryParam();
@@ -87,14 +89,14 @@ trait ImageResourceTrait
         $queryParam->setHeaderParameters(['X-Registry-Auth']);
 
         $url = '/images/{name}/push';
-        $url = str_replace('{name}', urlencode($name), $url);
-        $url      = $url . ('?' . $queryParam->buildQueryString($parameters));
+        $url = \str_replace('{name}', \urlencode($name), $url);
+        $url = $url.('?'.$queryParam->buildQueryString($parameters));
 
-        $headers  = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $headers = \array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
 
-        $body     = $queryParam->buildFormDataString($parameters);
+        $body = $queryParam->buildFormDataString($parameters);
 
-        $request  = $this->messageFactory->createRequest('POST', $url, $headers, $body);
+        $request = $this->messageFactory->createRequest('POST', $url, $headers, $body);
         $response = $this->httpClient->sendRequest($request);
 
         if (200 === $response->getStatusCode()) {
@@ -106,7 +108,7 @@ trait ImageResourceTrait
                 $pushImageInfoList = [];
 
                 $stream = new PushStream($response->getBody(), $this->serializer);
-                $stream->onFrame(function ($pushImageInfo) use (&$pushImageInfoList) {
+                $stream->onFrame(function ($pushImageInfo) use (&$pushImageInfoList): void {
                     $pushImageInfoList[] = $pushImageInfo;
                 });
                 $stream->wait();

--- a/src/Resource/SystemResourceTrait.php
+++ b/src/Resource/SystemResourceTrait.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Resource;
 
+use Docker\API\Resource\SystemResourceTrait as BaseSystemResourceTrait;
 use Docker\Docker;
 use Docker\Stream\EventStream;
 use Joli\Jane\OpenApi\Runtime\Client\Resource;
-use Docker\API\Resource\SystemResourceTrait as BaseSystemResourceTrait;
 
 trait SystemResourceTrait
 {
@@ -26,7 +28,7 @@ trait SystemResourceTrait
                 $eventList = [];
 
                 $stream = new EventStream($response->getBody(), $this->serializer);
-                $stream->onFrame(function ($event) use (&$eventList) {
+                $stream->onFrame(function ($event) use (&$eventList): void {
                     $eventList[] = $event;
                 });
                 $stream->wait();

--- a/src/Stream/AttachWebsocketStream.php
+++ b/src/Stream/AttachWebsocketStream.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
+
 use Psr\Http\Message\StreamInterface;
 
 /**
- * An interactive stream is used when communicating with an attached docker container
+ * An interactive stream is used when communicating with an attached docker container.
  *
  * It helps dealing with encoding and decoding frame from websocket protocol (hybi 10)
  *
@@ -21,33 +24,33 @@ class AttachWebsocketStream
     }
 
     /**
-     * Send input to the container
+     * Send input to the container.
      *
      * @param string $data Data to send
      */
-    public function write($data)
+    public function write($data): void
     {
-        $rand  = rand(0, 28);
+        $rand = \random_int(0, 28);
         $frame = [
-            'fin'      => 1,
-            'rsv1'     => 0,
-            'rsv2'     => 0,
-            'rsv3'     => 0,
-            'opcode'   => 1, // We always send text
-            'mask'     => 1,
-            'len'      => strlen($data),
-            'mask_key' => substr(md5(uniqid()), $rand, 4),
-            'data'     => $data,
+            'fin' => 1,
+            'rsv1' => 0,
+            'rsv2' => 0,
+            'rsv3' => 0,
+            'opcode' => 1, // We always send text
+            'mask' => 1,
+            'len' => \strlen($data),
+            'mask_key' => \substr(\md5(\uniqid()), $rand, 4),
+            'data' => $data,
         ];
 
-        if ($frame['mask'] == 1) {
-            for ($i = 0; $i < $frame['len']; $i++) {
-                $frame['data']{$i}
-                    = chr(ord($frame['data']{$i}) ^ ord($frame['mask_key']{$i % 4}));
+        if (1 === $frame['mask']) {
+            for ($i = 0; $i < $frame['len']; ++$i) {
+                $frame['data'][$i]
+                    = \chr(\ord($frame['data'][$i]) ^ \ord($frame['mask_key'][$i % 4]));
             }
         }
 
-        if ($frame['len'] > pow(2, 16)) {
+        if ($frame['len'] > 2 ** 16) {
             $len = 127;
         } elseif ($frame['len'] > 125) {
             $len = 126;
@@ -55,22 +58,22 @@ class AttachWebsocketStream
             $len = $frame['len'];
         }
 
-        $firstByte  = ($frame['fin'] << 7) | (($frame['rsv1'] << 7) >> 1) | (($frame['rsv2'] << 7) >> 2) | (($frame['rsv3'] << 7) >> 3) | (($frame['opcode'] << 4) >> 4);
+        $firstByte = ($frame['fin'] << 7) | (($frame['rsv1'] << 7) >> 1) | (($frame['rsv2'] << 7) >> 2) | (($frame['rsv3'] << 7) >> 3) | (($frame['opcode'] << 4) >> 4);
         $secondByte = ($frame['mask'] << 7) | (($len << 1) >> 1);
 
-        $this->socketWrite(chr($firstByte));
-        $this->socketWrite(chr($secondByte));
+        $this->socketWrite(\chr($firstByte));
+        $this->socketWrite(\chr($secondByte));
 
-        if ($len == 126) {
-            $this->socketWrite(pack('n', $frame['len']));
-        } elseif ($len == 127) {
+        if (126 === $len) {
+            $this->socketWrite(\pack('n', $frame['len']));
+        } elseif (127 === $len) {
             $higher = $frame['len'] >> 32;
-            $lower  = ($frame['len'] << 32) >> 32;
-            $this->socketWrite(pack('N', $higher));
-            $this->socketWrite(pack('N', $lower));
+            $lower = ($frame['len'] << 32) >> 32;
+            $this->socketWrite(\pack('N', $higher));
+            $this->socketWrite(\pack('N', $lower));
         }
 
-        if ($frame['mask'] == 1) {
+        if (1 === $frame['mask']) {
             $this->socketWrite($frame['mask_key']);
         }
 
@@ -78,63 +81,63 @@ class AttachWebsocketStream
     }
 
     /**
-     * Block until it receive a frame from websocket or return null if no more connexion
+     * Block until it receive a frame from websocket or return null if no more connexion.
      *
-     * @param int     $waitTime      Time to wait in seconds before return false
-     * @param int     $waitMicroTime Time to wait in microseconds before return false
-     * @param boolean $getFrame      Whether to return the frame of websocket or only the data
+     * @param int  $waitTime      Time to wait in seconds before return false
+     * @param int  $waitMicroTime Time to wait in microseconds before return false
+     * @param bool $getFrame      Whether to return the frame of websocket or only the data
      *
      * @return null|false|string|array Null for socket not available, false for no message, string for the last message and the frame array if $getFrame is set to true
      */
     public function read($waitTime = 0, $waitMicroTime = 200000, $getFrame = false)
     {
-        if (!is_resource($this->socket) || feof($this->socket)) {
+        if (!\is_resource($this->socket) || \feof($this->socket)) {
             return null;
         }
 
-        $read   = [$this->socket];
-        $write  = null;
+        $read = [$this->socket];
+        $write = null;
         $expect = null;
 
-        if (stream_select($read, $write, $expect, $waitTime, $waitMicroTime) == 0) {
+        if (0 === \stream_select($read, $write, $expect, $waitTime, $waitMicroTime)) {
             return false;
         }
 
-        $firstByte  = $this->socketRead(1);
-        $frame      = [];
-        $firstByte  = ord($firstByte);
-        $secondByte = ord($this->socketRead(1));
+        $firstByte = $this->socketRead(1);
+        $frame = [];
+        $firstByte = \ord($firstByte);
+        $secondByte = \ord($this->socketRead(1));
 
         // First byte decoding
-        $frame['fin']    = ($firstByte & 128) >> 7;
-        $frame['rsv1']   = ($firstByte & 64)  >> 6;
-        $frame['rsv2']   = ($firstByte & 32)  >> 5;
-        $frame['rsv3']   = ($firstByte & 16)  >> 4;
+        $frame['fin'] = ($firstByte & 128) >> 7;
+        $frame['rsv1'] = ($firstByte & 64) >> 6;
+        $frame['rsv2'] = ($firstByte & 32) >> 5;
+        $frame['rsv3'] = ($firstByte & 16) >> 4;
         $frame['opcode'] = ($firstByte & 15);
 
         // Second byte decoding
         $frame['mask'] = ($secondByte & 128) >> 7;
-        $frame['len']  = ($secondByte & 127);
+        $frame['len'] = ($secondByte & 127);
 
         // Get length of the frame
-        if ($frame['len'] == 126) {
-            $frame['len'] = unpack('n', $this->socketRead(2))[1];
-        } elseif ($frame['len'] == 127) {
-            list($higher, $lower) = array_values(unpack('N2', $this->socketRead(8)));
+        if (126 === $frame['len']) {
+            $frame['len'] = \unpack('n', $this->socketRead(2))[1];
+        } elseif (127 === $frame['len']) {
+            list($higher, $lower) = \array_values(\unpack('N2', $this->socketRead(8)));
             $frame['len'] = ($higher << 32) | $lower;
         }
 
         // Get the mask key if needed
-        if ($frame['mask'] == 1) {
+        if (1 === $frame['mask']) {
             $frame['mask_key'] = $this->socketRead(4);
         }
 
         $frame['data'] = $this->socketRead($frame['len']);
 
         // Decode data if needed
-        if ($frame['mask'] == 1) {
-            for ($i = 0; $i < $frame['len']; $i++) {
-                $frame['data']{$i} = chr(ord($frame['data']{$i}) ^ ord($frame['mask_key']{$i % 4}));
+        if (1 === $frame['mask']) {
+            for ($i = 0; $i < $frame['len']; ++$i) {
+                $frame['data'][$i] = \chr(\ord($frame['data'][$i]) ^ \ord($frame['mask_key'][$i % 4]));
             }
         }
 
@@ -142,11 +145,11 @@ class AttachWebsocketStream
             return $frame;
         }
 
-        return (string)$frame['data'];
+        return (string) $frame['data'];
     }
 
     /**
-     * Force to have something of the expected size (block)
+     * Force to have something of the expected size (block).
      *
      * @param $length
      *
@@ -154,17 +157,17 @@ class AttachWebsocketStream
      */
     private function socketRead($length)
     {
-        $read = "";
+        $read = '';
 
         do {
-            $read .= fread($this->socket, $length - strlen($read));
-        } while (strlen($read) < $length && !feof($this->socket));
+            $read .= \fread($this->socket, $length - \strlen($read));
+        } while (\strlen($read) < $length && !\feof($this->socket));
 
         return $read;
     }
 
     /**
-     * Write to the socket
+     * Write to the socket.
      *
      * @param $data
      *
@@ -172,6 +175,6 @@ class AttachWebsocketStream
      */
     private function socketWrite($data)
     {
-        return fwrite($this->socket, $data);
+        return \fwrite($this->socket, $data);
     }
 }

--- a/src/Stream/BuildStream.php
+++ b/src/Stream/BuildStream.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 /**
- * Represent a stream when building a dockerfile
+ * Represent a stream when building a dockerfile.
  *
  * Callable(s) passed to this stream will take a BuildInfo object as the first argument
  */
 class BuildStream extends MultiJsonStream
 {
     /**
-     * [@inheritdoc}
+     * [@inheritdoc}.
      */
     protected function getDecodeClass()
     {

--- a/src/Stream/CallbackStream.php
+++ b/src/Stream/CallbackStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 use Psr\Http\Message\StreamInterface;
@@ -16,43 +18,43 @@ abstract class CallbackStream
     }
 
     /**
-     * Called when there is a new frame from the stream
+     * Called when there is a new frame from the stream.
      *
      * @param callable $onNewFrame
      */
-    public function onFrame(callable $onNewFrame)
+    public function onFrame(callable $onNewFrame): void
     {
         $this->onNewFrameCallables[] = $onNewFrame;
     }
 
     /**
-     * Read a frame in the stream
+     * Read a frame in the stream.
      *
      * @return mixed
      */
     abstract protected function readFrame();
 
     /**
-     * Wait for stream to finish and call callables if defined
+     * Wait for stream to finish and call callables if defined.
      */
-    public function wait()
+    public function wait(): void
     {
         while (!$this->stream->eof()) {
             $frame = $this->readFrame();
 
-            if ($frame !== null) {
-                if (!is_array($frame)) {
+            if (null !== $frame) {
+                if (!\is_array($frame)) {
                     $frame = [$frame];
                 }
 
                 foreach ($this->onNewFrameCallables as $newFrameCallable) {
-                    call_user_func_array($newFrameCallable, $frame);
+                    \call_user_func_array($newFrameCallable, $frame);
                 }
             }
         }
     }
 
-    public function closeAndRead()
+    public function closeAndRead(): void
     {
         $this->stream->close();
         $this->wait();

--- a/src/Stream/CreateImageStream.php
+++ b/src/Stream/CreateImageStream.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 /**
- * Represent a stream when pull or importing an image (with the create api endpoint of image)
+ * Represent a stream when pull or importing an image (with the create api endpoint of image).
  *
  * Callable(s) passed to this stream will take a CreateImageInfo object as the first argument
  */
 class CreateImageStream extends MultiJsonStream
 {
     /**
-     * [@inheritdoc}
+     * [@inheritdoc}.
      */
     protected function getDecodeClass()
     {

--- a/src/Stream/DockerRawStream.php
+++ b/src/Stream/DockerRawStream.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 use Psr\Http\Message\StreamInterface;
 
 class DockerRawStream
 {
-    const HEADER = 'application/vnd.docker.raw-stream';
+    public const HEADER = 'application/vnd.docker.raw-stream';
 
     /** @var StreamInterface Stream for the response */
     protected $stream;
@@ -26,59 +28,59 @@ class DockerRawStream
     }
 
     /**
-     * Add a callable to read stdin
+     * Add a callable to read stdin.
      *
      * @param callable $callback
      */
-    public function onStdin(callable $callback)
+    public function onStdin(callable $callback): void
     {
         $this->onStdinCallables[] = $callback;
     }
 
     /**
-     * Add a callable to read stdout
+     * Add a callable to read stdout.
      *
      * @param callable $callback
      */
-    public function onStdout(callable $callback)
+    public function onStdout(callable $callback): void
     {
         $this->onStdoutCallables[] = $callback;
     }
 
     /**
-     * Add a callable to read stderr
+     * Add a callable to read stderr.
      *
      * @param callable $callback
      */
-    public function onStderr(callable $callback)
+    public function onStderr(callable $callback): void
     {
         $this->onStderrCallables[] = $callback;
     }
 
     /**
-     * Read a frame in the stream
+     * Read a frame in the stream.
      */
-    protected function readFrame()
+    protected function readFrame(): void
     {
-        $header  = $this->forceRead(8);
+        $header = $this->forceRead(8);
 
-        if (strlen($header) < 8) {
+        if (\strlen($header) < 8) {
             return;
         }
 
-        $decoded = unpack('C1type/C3/N1size', $header);
-        $output  = $this->forceRead($decoded['size']);
+        $decoded = \unpack('C1type/C3/N1size', $header);
+        $output = $this->forceRead($decoded['size']);
         $callbackList = [];
 
-        if ($decoded['type'] == 0) {
+        if (0 === $decoded['type']) {
             $callbackList = $this->onStdinCallables;
         }
 
-        if ($decoded['type'] == 1) {
+        if (1 === $decoded['type']) {
             $callbackList = $this->onStdoutCallables;
         }
 
-        if ($decoded['type'] == 2) {
+        if (2 === $decoded['type']) {
             $callbackList = $this->onStderrCallables;
         }
 
@@ -88,7 +90,7 @@ class DockerRawStream
     }
 
     /**
-     * Force to have something of the expected size (block)
+     * Force to have something of the expected size (block).
      *
      * @param $length
      *
@@ -96,19 +98,19 @@ class DockerRawStream
      */
     private function forceRead($length)
     {
-        $read = "";
+        $read = '';
 
         do {
-            $read .= $this->stream->read($length - strlen($read));
-        } while (strlen($read) < $length && !$this->stream->eof());
+            $read .= $this->stream->read($length - \strlen($read));
+        } while (\strlen($read) < $length && !$this->stream->eof());
 
         return $read;
     }
 
     /**
-     * Wait for stream to finish and call callables if defined
+     * Wait for stream to finish and call callables if defined.
      */
-    public function wait()
+    public function wait(): void
     {
         while (!$this->stream->eof()) {
             $this->readFrame();

--- a/src/Stream/EventStream.php
+++ b/src/Stream/EventStream.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 /**
- * Represent a stream when pushing an image to a repository (with the push api endpoint of image)
+ * Represent a stream when pushing an image to a repository (with the push api endpoint of image).
  *
  * Callable(s) passed to this stream will take a Event object as the first argument
  */
 class EventStream extends MultiJsonStream
 {
     /**
-     * [@inheritdoc}
+     * [@inheritdoc}.
      */
     protected function getDecodeClass()
     {

--- a/src/Stream/MultiJsonStream.php
+++ b/src/Stream/MultiJsonStream.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 use Psr\Http\Message\StreamInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
- * Represent a stream that decode a stream with multiple json in it
+ * Represent a stream that decode a stream with multiple json in it.
  */
 abstract class MultiJsonStream extends CallbackStream
 {
@@ -27,29 +29,29 @@ abstract class MultiJsonStream extends CallbackStream
     {
         $jsonFrameEnd = false;
         $lastJsonChar = '';
-        $inquote      = false;
-        $jsonFrame    = "";
-        $level        = 0;
+        $inquote = false;
+        $jsonFrame = '';
+        $level = 0;
 
         while (!$jsonFrameEnd && !$this->stream->eof()) {
-            $jsonChar   = $this->stream->read(1);
+            $jsonChar = $this->stream->read(1);
 
-            if ($jsonChar === '"' && $lastJsonChar !== '\\') {
+            if ('"' === $jsonChar && '\\' !== $lastJsonChar) {
                 $inquote = !$inquote;
             }
 
-            if (!$inquote && in_array($jsonChar, [" ", "\r", "\n", "\t"])) {
+            if (!$inquote && \in_array($jsonChar, [' ', "\r", "\n", "\t"], true)) {
                 continue;
             }
 
-            if (!$inquote && in_array($jsonChar, ['{', '['])) {
-                $level++;
+            if (!$inquote && \in_array($jsonChar, ['{', '['], true)) {
+                ++$level;
             }
 
-            if (!$inquote && in_array($jsonChar, ['}', ']'])) {
-                $level--;
+            if (!$inquote && \in_array($jsonChar, ['}', ']'], true)) {
+                --$level;
 
-                if ($level == 0) {
+                if (0 === $level) {
                     $jsonFrameEnd = true;
                     $jsonFrame .= $jsonChar;
 
@@ -65,11 +67,11 @@ abstract class MultiJsonStream extends CallbackStream
             return null;
         }
 
-        return $this->serializer->deserialize($jsonFrame, 'Docker\\API\\Model\\' . $this->getDecodeClass(), 'json');
+        return $this->serializer->deserialize($jsonFrame, 'Docker\\API\\Model\\'.$this->getDecodeClass(), 'json');
     }
 
     /**
-     * Get the decode class to pass to serializer
+     * Get the decode class to pass to serializer.
      *
      * @return string
      */

--- a/src/Stream/PushStream.php
+++ b/src/Stream/PushStream.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 /**
- * Represent a stream when pushing an image to a repository (with the push api endpoint of image)
+ * Represent a stream when pushing an image to a repository (with the push api endpoint of image).
  *
  * Callable(s) passed to this stream will take a PushImageInfo object as the first argument
  */
 class PushStream extends MultiJsonStream
 {
     /**
-     * [@inheritdoc}
+     * [@inheritdoc}.
      */
     protected function getDecodeClass()
     {

--- a/src/Stream/TarStream.php
+++ b/src/Stream/TarStream.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Stream;
 
 use GuzzleHttp\Psr7\Stream;
 
 /**
- * This class avoid a bug in PHP where fstat return a size of 0 for process stream
+ * This class avoid a bug in PHP where fstat return a size of 0 for process stream.
  */
 class TarStream extends Stream
 {

--- a/tests/Context/ContextBuilderTest.php
+++ b/tests/Context/ContextBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests\Context;
 
 use Docker\Context\ContextBuilder;
@@ -7,7 +9,7 @@ use Docker\Tests\TestCase;
 
 class ContextBuilderTest extends TestCase
 {
-    public function testRemovesFilesOnDestruct()
+    public function testRemovesFilesOnDestruct(): void
     {
         $contextBuilder = new ContextBuilder();
         $context = $contextBuilder->getContext();
@@ -19,7 +21,7 @@ class ContextBuilderTest extends TestCase
         $this->assertFileNotExists($context->getDirectory().'/Dockerfile');
     }
 
-    public function testWritesContextToDisk()
+    public function testWritesContextToDisk(): void
     {
         $contextBuilder = new ContextBuilder();
         $context = $contextBuilder->getContext();
@@ -27,7 +29,7 @@ class ContextBuilderTest extends TestCase
         $this->assertFileExists($context->getDirectory().'/Dockerfile');
     }
 
-    public function testHasDefaultFrom()
+    public function testHasDefaultFrom(): void
     {
         $contextBuilder = new ContextBuilder();
         $context = $contextBuilder->getContext();
@@ -35,7 +37,7 @@ class ContextBuilderTest extends TestCase
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', 'FROM base');
     }
 
-    public function testUsesCustomFrom()
+    public function testUsesCustomFrom(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->from('ubuntu:precise');
@@ -45,7 +47,7 @@ class ContextBuilderTest extends TestCase
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', 'FROM ubuntu:precise');
     }
 
-    public function testCreatesTmpDirectory()
+    public function testCreatesTmpDirectory(): void
     {
         $contextBuilder = new ContextBuilder();
         $context = $contextBuilder->getContext();
@@ -53,27 +55,27 @@ class ContextBuilderTest extends TestCase
         $this->assertFileExists($context->getDirectory());
     }
 
-    public function testWriteTmpFiles()
+    public function testWriteTmpFiles(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->add('/foo', 'random content');
 
-        $context  = $contextBuilder->getContext();
-        $filename = preg_replace(<<<DOCKERFILE
+        $context = $contextBuilder->getContext();
+        $filename = \preg_replace(<<<DOCKERFILE
 #FROM base
 ADD (.+?) /foo#
 DOCKERFILE
-            , "$1", $context->getDockerfileContent());
+            , '$1', $context->getDockerfileContent());
 
         $this->assertStringEqualsFile($context->getDirectory().'/'.$filename, 'random content');
     }
 
-    public function testWritesAddCommands()
+    public function testWritesAddCommands(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->add('/foo', 'foo file content');
 
-        $context  = $contextBuilder->getContext();
+        $context = $contextBuilder->getContext();
 
         $this->assertRegExp(<<<DOCKERFILE
 #FROM base
@@ -83,12 +85,12 @@ DOCKERFILE
         );
     }
 
-    public function testWritesRunCommands()
+    public function testWritesRunCommands(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->run('foo command');
 
-        $context  = $contextBuilder->getContext();
+        $context = $contextBuilder->getContext();
 
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', <<<DOCKERFILE
 FROM base
@@ -97,12 +99,12 @@ DOCKERFILE
         );
     }
 
-    public function testWritesEnvCommands()
+    public function testWritesEnvCommands(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->env('foo', 'bar');
 
-        $context  = $contextBuilder->getContext();
+        $context = $contextBuilder->getContext();
 
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', <<<DOCKERFILE
 FROM base
@@ -111,12 +113,12 @@ DOCKERFILE
         );
     }
 
-    public function testWritesCopyCommands()
+    public function testWritesCopyCommands(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->copy('/foo', '/bar');
 
-        $context  = $contextBuilder->getContext();
+        $context = $contextBuilder->getContext();
 
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', <<<DOCKERFILE
 FROM base
@@ -125,12 +127,12 @@ DOCKERFILE
         );
     }
 
-    public function testWritesWorkdirCommands()
+    public function testWritesWorkdirCommands(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->workdir('/foo');
 
-        $context  = $contextBuilder->getContext();
+        $context = $contextBuilder->getContext();
 
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', <<<DOCKERFILE
 FROM base
@@ -139,12 +141,12 @@ DOCKERFILE
         );
     }
 
-    public function testWritesExposeCommands()
+    public function testWritesExposeCommands(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->expose('80');
 
-        $context  = $contextBuilder->getContext();
+        $context = $contextBuilder->getContext();
 
         $this->assertStringEqualsFile($context->getDirectory().'/Dockerfile', <<<DOCKERFILE
 FROM base

--- a/tests/Context/ContextTest.php
+++ b/tests/Context/ContextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests\Context;
 
 use Docker\Context\Context;
@@ -8,20 +10,20 @@ use Symfony\Component\Process\Process;
 
 class ContextTest extends TestCase
 {
-    public function testReturnsValidTarContent()
+    public function testReturnsValidTarContent(): void
     {
-        $directory = __DIR__.DIRECTORY_SEPARATOR."context-test";
+        $directory = __DIR__.DIRECTORY_SEPARATOR.'context-test';
 
         $context = new Context($directory);
         $process = new Process('/usr/bin/env tar c .', $directory);
         $process->run();
 
-        $this->assertEquals(strlen($process->getOutput()), strlen($context->toTar()));
+        $this->assertSame(\strlen($process->getOutput()), \strlen($context->toTar()));
     }
 
-    public function testReturnsValidTarStream()
+    public function testReturnsValidTarStream(): void
     {
-        $directory = __DIR__.DIRECTORY_SEPARATOR."context-test";
+        $directory = __DIR__.DIRECTORY_SEPARATOR.'context-test';
 
         $context = new Context($directory);
         $this->assertInternalType('resource', $context->toStream());

--- a/tests/DockerAsyncTest.php
+++ b/tests/DockerAsyncTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests;
 
 use Amp\Loop;
@@ -8,7 +10,7 @@ use Docker\DockerAsync;
 
 class DockerAsyncTest extends \PHPUnit\Framework\TestCase
 {
-    public function testAsync()
+    public function testAsync(): void
     {
         $this->markTestSkipped('Need update of socket library');
 
@@ -25,7 +27,7 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
             $containerStart = yield $docker->containerStart($containerCreate->getId());
             $containerInfo = yield $docker->containerInspect($containerCreate->getId());
 
-            $this->assertEquals($containerCreate->getId(), $containerInfo->getId());
+            $this->assertSame($containerCreate->getId(), $containerInfo->getId());
         });
     }
 }

--- a/tests/Resource/ContainerResourceTest.php
+++ b/tests/Resource/ContainerResourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests\Resource;
 
 use Docker\API\Model\ContainersCreatePostBody;
@@ -9,7 +11,7 @@ use Docker\Tests\TestCase;
 class ContainerResourceTest extends TestCase
 {
     /**
-     * Return the container manager
+     * Return the container manager.
      */
     private function getManager()
     {
@@ -17,16 +19,16 @@ class ContainerResourceTest extends TestCase
     }
 
     /**
-     * Be sure to have image before doing test
+     * Be sure to have image before doing test.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::getDocker()->imageCreate(null, [
-            'fromImage' => 'busybox:latest'
+            'fromImage' => 'busybox:latest',
         ]);
     }
 
-    public function testAttach()
+    public function testAttach(): void
     {
         $containerConfig = new ContainersCreatePostBody();
         $containerConfig->setImage('busybox:latest');
@@ -40,8 +42,8 @@ class ContainerResourceTest extends TestCase
             'stdout' => true,
         ]);
 
-        $stdoutFull = "";
-        $dockerRawStream->onStdout(function ($stdout) use (&$stdoutFull) {
+        $stdoutFull = '';
+        $dockerRawStream->onStdout(function ($stdout) use (&$stdoutFull): void {
             $stdoutFull .= $stdout;
         });
 
@@ -50,10 +52,10 @@ class ContainerResourceTest extends TestCase
 
         $dockerRawStream->wait();
 
-        $this->assertEquals("output", $stdoutFull);
+        $this->assertSame('output', $stdoutFull);
     }
 
-    public function testAttachWebsocket()
+    public function testAttachWebsocket(): void
     {
         $containerConfig = new ContainersCreatePostBody();
         $containerConfig->setImage('busybox:latest');
@@ -70,7 +72,7 @@ class ContainerResourceTest extends TestCase
             'stream' => true,
             'stdout' => true,
             'stderr' => true,
-            'stdin'  => true,
+            'stdin' => true,
         ]);
 
         $this->getManager()->containerStart($containerCreateResult->getId());
@@ -85,19 +87,19 @@ class ContainerResourceTest extends TestCase
         $webSocketStream->write("echo test\n");
 
         // Test for echo present (stdin)
-        $output = "";
+        $output = '';
 
-        while (($data = $webSocketStream->read()) != false) {
+        while (false !== ($data = $webSocketStream->read())) {
             $output .= $data;
         }
 
-        $this->assertContains("echo", $output);
+        $this->assertContains('echo', $output);
 
         // Exit the container
         $webSocketStream->write("exit\n");
     }
 
-    public function testLogs()
+    public function testLogs(): void
     {
         $containerConfig = new ContainersCreatePostBody();
         $containerConfig->setImage('busybox:latest');
@@ -115,7 +117,6 @@ class ContainerResourceTest extends TestCase
             'stderr' => true,
         ], Docker::FETCH_OBJECT);
 
-
-        $this->assertContains("output", $logs['stdout'][0]);
+        $this->assertContains('output', $logs['stdout'][0]);
     }
 }

--- a/tests/Resource/ExecResourceTest.php
+++ b/tests/Resource/ExecResourceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests\Resource;
 
 use Docker\API\Model\ContainersCreatePostBody;
@@ -13,21 +15,21 @@ use Docker\Tests\TestCase;
 class ExecResourceTest extends TestCase
 {
     /**
-     * Return the container manager
+     * Return the container manager.
      */
     private function getManager()
     {
         return self::getDocker();
     }
 
-    public function testStartStream()
+    public function testStartStream(): void
     {
         $createContainerResult = $this->createContainer();
 
         $execConfig = new ContainersIdExecPostBody();
         $execConfig->setAttachStdout(true);
         $execConfig->setAttachStderr(true);
-        $execConfig->setCmd(["echo", "output"]);
+        $execConfig->setCmd(['echo', 'output']);
 
         $execCreateResult = $this->getManager()->containerExec($createContainerResult->getId(), $execConfig);
 
@@ -39,25 +41,25 @@ class ExecResourceTest extends TestCase
 
         $this->assertInstanceOf(DockerRawStream::class, $stream);
 
-        $stdoutFull = "";
-        $stream->onStdout(function ($stdout) use (&$stdoutFull) {
+        $stdoutFull = '';
+        $stream->onStdout(function ($stdout) use (&$stdoutFull): void {
             $stdoutFull .= $stdout;
         });
         $stream->wait();
 
-        $this->assertEquals("output\n", $stdoutFull);
+        $this->assertSame("output\n", $stdoutFull);
 
         self::getDocker()->containerKill($createContainerResult->getId(), [
-            'signal' => 'SIGKILL'
+            'signal' => 'SIGKILL',
         ]);
     }
 
-    public function testExecFind()
+    public function testExecFind(): void
     {
         $createContainerResult = $this->createContainer();
 
         $execConfig = new ContainersIdExecPostBody();
-        $execConfig->setCmd(["/bin/true"]);
+        $execConfig->setCmd(['/bin/true']);
         $execCreateResult = $this->getManager()->containerExec($createContainerResult->getId(), $execConfig);
 
         $execStartConfig = new ExecIdStartPostBody();
@@ -71,7 +73,7 @@ class ExecResourceTest extends TestCase
         $this->assertInstanceOf(ExecIdJsonGetResponse200::class, $execFindResult);
 
         self::getDocker()->containerKill($createContainerResult->getId(), [
-            'signal' => 'SIGKILL'
+            'signal' => 'SIGKILL',
         ]);
     }
 

--- a/tests/Resource/ImageResourceTest.php
+++ b/tests/Resource/ImageResourceTest.php
@@ -1,25 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests\Resource;
 
 use Docker\API\Model\AuthConfig;
 use Docker\Context\ContextBuilder;
 use Docker\Docker;
-use Docker\Resource\ImageResource;
 use Docker\Tests\TestCase;
 use Joli\Jane\OpenApi\Runtime\Client\Resource;
 
 class ImageResourceTest extends TestCase
 {
     /**
-     * Return a container manager
+     * Return a container manager.
      */
     private function getManager()
     {
         return self::getDocker();
     }
 
-    public function testBuildStream()
+    public function testBuildStream(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->from('ubuntu:precise');
@@ -30,17 +31,17 @@ class ImageResourceTest extends TestCase
 
         $this->assertInstanceOf('Docker\Stream\BuildStream', $buildStream);
 
-        $lastMessage = "";
+        $lastMessage = '';
 
-        $buildStream->onFrame(function ($frame) use (&$lastMessage) {
+        $buildStream->onFrame(function ($frame) use (&$lastMessage): void {
             $lastMessage = $frame->getStream();
         });
         $buildStream->wait();
 
-        $this->assertContains("Successfully", $lastMessage);
+        $this->assertContains('Successfully', $lastMessage);
     }
 
-    public function testBuildObject()
+    public function testBuildObject(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->from('ubuntu:precise');
@@ -50,40 +51,40 @@ class ImageResourceTest extends TestCase
         $buildInfos = $this->getManager()->imageBuild($context->read(), ['t' => 'test-image']);
 
         $this->assertInternalType('array', $buildInfos);
-        $this->assertContains("Successfully", $buildInfos[count($buildInfos) - 1]->getStream());
+        $this->assertContains('Successfully', $buildInfos[\count($buildInfos) - 1]->getStream());
     }
 
-    public function testCreateStream()
+    public function testCreateStream(): void
     {
         $createImageStream = $this->getManager()->imageCreate(null, [
-            'fromImage' => 'registry:latest'
+            'fromImage' => 'registry:latest',
         ], Docker::FETCH_STREAM);
 
         $this->assertInstanceOf('Docker\Stream\CreateImageStream', $createImageStream);
 
         $firstMessage = null;
 
-        $createImageStream->onFrame(function ($createImageInfo) use (&$firstMessage) {
+        $createImageStream->onFrame(function ($createImageInfo) use (&$firstMessage): void {
             if (null === $firstMessage) {
                 $firstMessage = $createImageInfo->getStatus();
             }
         });
         $createImageStream->wait();
 
-        $this->assertContains("Pulling from library/registry", $firstMessage);
+        $this->assertContains('Pulling from library/registry', $firstMessage);
     }
 
-    public function testCreateObject()
+    public function testCreateObject(): void
     {
         $createImagesInfos = $this->getManager()->imageCreate(null, [
-            'fromImage' => 'registry:latest'
+            'fromImage' => 'registry:latest',
         ], Resource::FETCH_OBJECT);
 
         $this->assertInternalType('array', $createImagesInfos);
-        $this->assertContains("Pulling from library/registry", $createImagesInfos[0]->getStatus());
+        $this->assertContains('Pulling from library/registry', $createImagesInfos[0]->getStatus());
     }
 
-    public function testPushStream()
+    public function testPushStream(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->from('ubuntu:precise');
@@ -95,24 +96,24 @@ class ImageResourceTest extends TestCase
         $registryConfig = new AuthConfig();
         $registryConfig->setServeraddress('localhost:5000');
         $pushImageStream = $this->getManager()->imagePush('localhost:5000/test-image', [
-            'X-Registry-Auth' => $registryConfig
+            'X-Registry-Auth' => $registryConfig,
         ], Docker::FETCH_STREAM);
 
         $this->assertInstanceOf('Docker\Stream\PushStream', $pushImageStream);
 
         $firstMessage = null;
 
-        $pushImageStream->onFrame(function ($pushImageInfo) use (&$firstMessage) {
+        $pushImageStream->onFrame(function ($pushImageInfo) use (&$firstMessage): void {
             if (null === $firstMessage) {
                 $firstMessage = $pushImageInfo->getStatus();
             }
         });
         $pushImageStream->wait();
 
-        $this->assertContains("repository [localhost:5000/test-image]", $firstMessage);
+        $this->assertContains('repository [localhost:5000/test-image]', $firstMessage);
     }
 
-    public function testPushObject()
+    public function testPushObject(): void
     {
         $contextBuilder = new ContextBuilder();
         $contextBuilder->from('ubuntu:precise');
@@ -124,10 +125,10 @@ class ImageResourceTest extends TestCase
         $registryConfig = new AuthConfig();
         $registryConfig->setServeraddress('localhost:5000');
         $pushImageInfos = $this->getManager()->imagePush('localhost:5000/test-image', [
-            'X-Registry-Auth' => $registryConfig
+            'X-Registry-Auth' => $registryConfig,
         ], Resource::FETCH_OBJECT);
 
         $this->assertInternalType('array', $pushImageInfos);
-        $this->assertContains("repository [localhost:5000/test-image]", $pushImageInfos[0]->getStatus());
+        $this->assertContains('repository [localhost:5000/test-image]', $pushImageInfos[0]->getStatus());
     }
 }

--- a/tests/Resource/SystemResourceTest.php
+++ b/tests/Resource/SystemResourceTest.php
@@ -1,50 +1,48 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests\Resource;
 
-use Docker\API\Model\Event;
 use Docker\API\Model\EventsGetResponse200;
 use Docker\Docker;
-use Docker\Manager\MiscManager;
-use Docker\Resource\SystemResource;
 use Docker\Tests\TestCase;
-use Joli\Jane\OpenApi\Runtime\Client\Resource;
 
 class SystemResourceTest extends TestCase
 {
     /**
-     * Return a container manager
+     * Return a container manager.
      */
     private function getManager()
     {
         return self::getDocker();
     }
 
-    public function testGetEventsStream()
+    public function testGetEventsStream(): void
     {
         $stream = $this->getManager()->systemEvents([
-            'since' => time() - 1,
-            'until' => time() + 4
+            'since' => \time() - 1,
+            'until' => \time() + 4,
         ], Docker::FETCH_STREAM);
         $lastEvent = null;
 
-        $stream->onFrame(function ($event) use (&$lastEvent) {
+        $stream->onFrame(function ($event) use (&$lastEvent): void {
             $lastEvent = $event;
         });
 
         self::getDocker()->imageCreate(null, [
-            'fromImage' => 'busybox:latest'
+            'fromImage' => 'busybox:latest',
         ]);
         $stream->wait();
 
         $this->assertInstanceOf(EventsGetResponse200::class, $lastEvent);
     }
 
-    public function testGetEventsObject()
+    public function testGetEventsObject(): void
     {
         $events = $this->getManager()->systemEvents([
-            'since' => time() - (60 * 60 * 24),
-            'until' => time()
+            'since' => \time() - (60 * 60 * 24),
+            'until' => \time(),
         ], Docker::FETCH_OBJECT);
 
         $this->assertInternalType('array', $events);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Docker\Tests;
 
 use Docker\Docker;


### PR DESCRIPTION
The fixer is required, but never setup.

Now it is. :smile: 

Some points:

- I took benefit of not release yet version to introduce risky fixers, especially for PHP and strict typing.
- I introduced PHP 7.1 rule. So #264 must be discussed and merged before this one
- I add the `generated` folder to the configuration. This may have to be modified after #262 

I also add some rules. Feel free to comment to update/remove/add some. Here is the list: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.7/README.rst