### PR TITLE
Fix issue with labels for images

### DIFF
--- a/generated/Resource/ImageResource.php
+++ b/generated/Resource/ImageResource.php
@@ -62,6 +62,7 @@ class ImageResource extends Resource
      *     @var string $pull Attempt to pull the image even if an older image exists locally
      *     @var bool $rm Remove intermediate containers after a successful build (default behavior).
      *     @var bool $forcerm always remove intermediate containers (includes rm)
+     *     @var array $label Set labels for an image.
      *     @var int $memory Set memory limit for build.
      *     @var int $memswap Total memory (memory + swap), -1 to disable swap.
      *     @var int $cpushares CPU shares (relative weight).
@@ -88,6 +89,7 @@ class ImageResource extends Resource
         $queryParam->setDefault('pull', null);
         $queryParam->setDefault('rm', true);
         $queryParam->setDefault('forcerm', false);
+        $queryParam->setDefault('labels', null);
         $queryParam->setDefault('memory', null);
         $queryParam->setDefault('memswap', null);
         $queryParam->setDefault('cpushares', null);

--- a/tests/Manager/ImageManagerTest.php
+++ b/tests/Manager/ImageManagerTest.php
@@ -93,7 +93,10 @@ class ImageManagerTest extends TestCase
         $contextBuilder->add('/test', 'test file content');
 
         $context = $contextBuilder->getContext();
-        $this->getManager()->build($context->read(), ['t' => 'localhost:5000/test-image'], ImageManager::FETCH_OBJECT);
+        $this->getManager()->build($context->read(), [
+            't' => 'localhost:5000/test-image',
+            'labels' => [ 'test-label' => 'yes' ]
+        ], ImageManager::FETCH_OBJECT);
 
         $registryConfig = new AuthConfig();
         $registryConfig->setServeraddress('localhost:5000');


### PR DESCRIPTION
In order to add labels to docker images while building this commit adds
the parameter to the `build` function in the `ImageResource` class. This
commit fixes issue #230.