### PR TITLE
Submit network connect/disconnect as json mime type

### DIFF
--- a/generated/1.33/Resource/NetworkResource.php
+++ b/generated/1.33/Resource/NetworkResource.php
@@ -189,7 +189,7 @@ class NetworkResource extends Resource
         $url        = '/v1.33/networks/{id}/connect';
         $url        = str_replace('{id}', urlencode($id), $url);
         $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
-        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $headers    = array_merge(['Host' => 'localhost', 'Accept' => ['application/json']], $queryParam->buildHeaders($parameters));
         $body       = $this->serializer->serialize($container, 'json');
         $request    = $this->messageFactory->createRequest('POST', $url, $headers, $body);
         $promise    = $this->httpClient->sendAsyncRequest($request);
@@ -229,7 +229,7 @@ class NetworkResource extends Resource
         $url        = '/v1.33/networks/{id}/disconnect';
         $url        = str_replace('{id}', urlencode($id), $url);
         $url        = $url . ('?' . $queryParam->buildQueryString($parameters));
-        $headers    = array_merge(['Host' => 'localhost'], $queryParam->buildHeaders($parameters));
+        $headers    = array_merge(['Host' => 'localhost', 'Accept' => ['application/json']], $queryParam->buildHeaders($parameters));
         $body       = $this->serializer->serialize($container, 'json');
         $request    = $this->messageFactory->createRequest('POST', $url, $headers, $body);
         $promise    = $this->httpClient->sendAsyncRequest($request);


### PR DESCRIPTION
Without the correct mime type this fails with:

Dec 14 17:32:23 dev-demo dockerd[11262]: time="2017-12-14T17:32:23.478068505Z" level=error msg="Error parsing media type:  error: mime: no media type"

I understand the lib is generated with jane, so this may be better handled with a change elsewhere.