### PR TITLE
Refactored context cleanup to happen inside context instead of contex…

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -48,9 +48,9 @@ class Context implements ContextInterface
     private $format = self::FORMAT_STREAM;
 
     /**
-     * @param string $directory Directory of context
-     * @param string $format    Format to use when sending the call (stream or tar: string)
-     * @param Filesystem $fs Filesystem object for cleaning the context directory on destruction.
+     * @param string     $directory Directory of context
+     * @param string     $format    Format to use when sending the call (stream or tar: string)
+     * @param Filesystem $fs        filesystem object for cleaning the context directory on destruction
      */
     public function __construct($directory, $format = self::FORMAT_STREAM, Filesystem $fs = null)
     {
@@ -155,9 +155,9 @@ class Context implements ContextInterface
     }
 
     /**
-     * @param bool $value Whether to remove the context directory.
+     * @param bool $value whether to remove the context directory
      */
-    public function setCleanup(bool $value)
+    public function setCleanup(bool $value): void
     {
         $this->cleanup = $value;
     }

--- a/src/Context/ContextBuilder.php
+++ b/src/Context/ContextBuilder.php
@@ -9,11 +9,6 @@ use Symfony\Component\Filesystem\Filesystem;
 class ContextBuilder
 {
     /**
-     * @var string
-     */
-    private $directory;
-
-    /**
      * @var array
      */
     private $commands = [];
@@ -24,7 +19,7 @@ class ContextBuilder
     private $files = [];
 
     /**
-     * @var \Symfony\Component\Filesystem\Filesystem
+     * @var Filesystem
      */
     private $fs;
 
@@ -260,23 +255,13 @@ class ContextBuilder
      */
     public function getContext()
     {
-        if (null !== $this->directory) {
-            $this->cleanDirectory();
-        }
+        $directory = \sys_get_temp_dir() . '/ctb-' . microtime();
+        $this->fs->mkdir($directory);
+        $this->write($directory);
 
-        $this->directory = \sys_get_temp_dir().'/'.\md5(\serialize($this->commands));
-        $this->fs->mkdir($this->directory);
-        $this->write($this->directory);
-
-        return new Context($this->directory, $this->format);
-    }
-
-    /**
-     * @void
-     */
-    public function __destruct()
-    {
-        $this->cleanDirectory();
+        $result = new Context($directory, $this->format, $this->fs);
+        $result->setCleanup(true);
+        return $result;
     }
 
     /**
@@ -403,11 +388,4 @@ class ContextBuilder
         return $this->files[$hash];
     }
 
-    /**
-     * Clean directory generated.
-     */
-    private function cleanDirectory(): void
-    {
-        $this->fs->remove($this->directory);
-    }
 }

--- a/src/Context/ContextBuilder.php
+++ b/src/Context/ContextBuilder.php
@@ -255,12 +255,13 @@ class ContextBuilder
      */
     public function getContext()
     {
-        $directory = \sys_get_temp_dir() . '/ctb-' . microtime();
+        $directory = \sys_get_temp_dir().'/ctb-'.\microtime();
         $this->fs->mkdir($directory);
         $this->write($directory);
 
         $result = new Context($directory, $this->format, $this->fs);
         $result->setCleanup(true);
+
         return $result;
     }
 
@@ -387,5 +388,4 @@ class ContextBuilder
 
         return $this->files[$hash];
     }
-
 }

--- a/tests/Context/ContextBuilderTest.php
+++ b/tests/Context/ContextBuilderTest.php
@@ -9,18 +9,6 @@ use Docker\Tests\TestCase;
 
 class ContextBuilderTest extends TestCase
 {
-    public function testRemovesFilesOnDestruct(): void
-    {
-        $contextBuilder = new ContextBuilder();
-        $context = $contextBuilder->getContext();
-
-        $this->assertFileExists($context->getDirectory().'/Dockerfile');
-
-        unset($contextBuilder);
-
-        $this->assertFileNotExists($context->getDirectory().'/Dockerfile');
-    }
-
     public function testWritesContextToDisk(): void
     {
         $contextBuilder = new ContextBuilder();

--- a/tests/Context/ContextTest.php
+++ b/tests/Context/ContextTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Docker\Tests\Context;
 
 use Docker\Context\Context;
+use Docker\Context\ContextBuilder;
 use Docker\Tests\TestCase;
 use Symfony\Component\Process\Process;
 
@@ -28,4 +29,17 @@ class ContextTest extends TestCase
         $context = new Context($directory);
         $this->assertInternalType('resource', $context->toStream());
     }
+
+    public function testRemovesFilesOnDestruct(): void
+    {
+        $context = (new ContextBuilder())->getContext();
+        $file = $context->getDirectory().'/Dockerfile';
+        $this->assertFileExists($file);
+
+        unset($context);
+
+        $this->assertFileNotExists($file);
+    }
+
+
 }

--- a/tests/Context/ContextTest.php
+++ b/tests/Context/ContextTest.php
@@ -40,6 +40,4 @@ class ContextTest extends TestCase
 
         $this->assertFileNotExists($file);
     }
-
-
 }


### PR DESCRIPTION
…t builder

The `ContextBuilder` would cleanup the context directory upon its destruction, however there is no guarantee that there are no `Context` objects still referring to the directory.

Solution:
1. Remove reuse of context directory. Instead each time `getContext()` is called a unique directory is created.
2. `Context` becomes the "owner" of its directory, the context builder does not have a reference to it.
3. Upon destruction the `Context` object will remove the directory.


