### PR TITLE
Added tests and fixed escape bugs in JsonMultiStream

### DIFF
--- a/src/Stream/MultiJsonStream.php
+++ b/src/Stream/MultiJsonStream.php
@@ -33,6 +33,7 @@ abstract class MultiJsonStream extends CallbackStream
         $jsonFrame = '';
         $level = 0;
 
+        // This is a
         while (!$jsonFrameEnd && !$this->stream->eof()) {
             $jsonChar = $this->stream->read(1);
 
@@ -40,6 +41,7 @@ abstract class MultiJsonStream extends CallbackStream
                 $inquote = !$inquote;
             }
 
+            // We ignore white space when it is not part of a quoted string.
             if (!$inquote && \in_array($jsonChar, [' ', "\r", "\n", "\t"], true)) {
                 continue;
             }
@@ -54,12 +56,13 @@ abstract class MultiJsonStream extends CallbackStream
                 if (0 === $level) {
                     $jsonFrameEnd = true;
                     $jsonFrame .= $jsonChar;
-
+                    $lastJsonChar = '';
                     continue;
                 }
             }
 
             $jsonFrame .= $jsonChar;
+            $lastJsonChar = $jsonChar;
         }
 
         // Invalid last json, or timeout, or connection close before receiving

--- a/tests/Stream/MultiJsonStreamTest.php
+++ b/tests/Stream/MultiJsonStreamTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docker\Tests\Stream;
+
+use Docker\API\Model\BuildInfo;
+use Docker\Stream\MultiJsonStream;
+use Docker\Tests\TestCase;
+use GuzzleHttp\Psr7\BufferStream;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class MultiJsonStreamTest extends TestCase
+{
+    public function jsonStreamDataProvider()
+    {
+        return [
+            [
+                '{}{"abc":"def"}',
+                ['{}', '{"abc":"def"}'],
+            ],
+            [
+                 '{"test": "abc\"\""}',
+                ['{"test":"abc\"\""}'],
+            ],
+            [
+                '{"test": "abc\"{{-}"}',
+                ['{"test":"abc\"{{-}"}'],
+            ],
+        ];
+    }
+
+    /**
+     * @param $jsonStream
+     * @param $jsonParts
+     * @dataProvider jsonStreamDataProvider
+     */
+    public function testReadJsonEscapedDoubleQuote(string $jsonStream, array $jsonParts): void
+    {
+        $stream = new BufferStream();
+        $stream->write($jsonStream);
+
+        $serializer = $this->getMockBuilder(SerializerInterface::class)
+            ->getMock();
+
+        $serializer
+            ->expects($this->exactly(\count($jsonParts)))
+            ->method('deserialize')
+                ->withConsecutive(...\array_map(function ($part) {
+                    return [$part, BuildInfo::class, 'json', []];
+                }, $jsonParts))
+        ;
+
+        $stub = $this->getMockForAbstractClass(MultiJsonStream::class, [$stream, $serializer]);
+        $stub->expects($this->any())
+            ->method('getDecodeClass')
+            ->willReturn('BuildInfo');
+
+        $stub->wait();
+    }
+}


### PR DESCRIPTION
This patch fixes issues in dealing with escaped characters in side quoted strings.

Note that 1.x also has this bug.