### PR TITLE
feat: Consume Docker system events asynchronously

### DIFF
--- a/src/Client/AmpArtaxStreamEndpoint.php
+++ b/src/Client/AmpArtaxStreamEndpoint.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docker\Client;
+
+use Amp\Artax\Response;
+use Amp\CancellationTokenSource;
+use Amp\Promise;
+use Jane\OpenApiRuntime\Client\Client;
+use Symfony\Component\Serializer\SerializerInterface;
+
+interface AmpArtaxStreamEndpoint
+{
+    /**
+     * Parse and transform an Artax InputStream chunk into a different object.
+     *
+     * Implementations may vary depending the status code of the response and the fetch mode used.
+     */
+    public function parseArtaxStreamResponse(
+        Response $response,
+        SerializerInterface $serializer,
+        CancellationTokenSource $cancellationTokenSource,
+        string $fetchMode = Client::FETCH_OBJECT
+    ): Promise;
+}

--- a/src/Client/AmpArtaxStreamEndpointTrait.php
+++ b/src/Client/AmpArtaxStreamEndpointTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docker\Client;
+
+use Amp\Artax\Response;
+use Amp\CancellationTokenSource;
+use Amp\Promise;
+use Docker\Stream\ArtaxCallbackStream;
+use Jane\OpenApiRuntime\Client\Client;
+use Jane\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
+use Symfony\Component\Serializer\SerializerInterface;
+use function Amp\call;
+
+trait AmpArtaxStreamEndpointTrait
+{
+    abstract protected function transformResponseBody(string $body, int $status, SerializerInterface $serializer);
+
+    public function parseArtaxStreamResponse(
+        Response $response,
+        SerializerInterface $serializer,
+        CancellationTokenSource $cancellationTokenSource,
+        string $fetchMode = Client::FETCH_OBJECT
+    ): Promise {
+        if (!\in_array($fetchMode, [Client::FETCH_OBJECT, Client::FETCH_RESPONSE], true)) {
+            throw new InvalidFetchModeException(\sprintf('Fetch mode %s is not supported', $fetchMode));
+        }
+
+        return call(function () use ($response, $serializer, $fetchMode, $cancellationTokenSource) {
+            $responseTransformer = null;
+            if (Client::FETCH_OBJECT === $fetchMode) {
+                $responseTransformer = function ($chunk) use ($response, $serializer) {
+                    return $this->transformResponseBody($chunk, $response->getStatus(), $serializer);
+                };
+            }
+
+            return new ArtaxCallbackStream($response->getBody(), $cancellationTokenSource, $responseTransformer);
+        });
+    }
+}

--- a/src/Client/ProvideAmpArtaxClientOptions.php
+++ b/src/Client/ProvideAmpArtaxClientOptions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ElevenLabs\Docker\Client;
+
+namespace Docker\Client;
+
+interface ProvideAmpArtaxClientOptions
+{
+    /**
+     * Return a list of options for the Artax client.
+     */
+    public function getAmpArtaxClientOptions(): array;
+}

--- a/src/DockerAsync.php
+++ b/src/DockerAsync.php
@@ -4,7 +4,15 @@ declare(strict_types=1);
 
 namespace Docker;
 
+use Amp\Artax\Request;
+use Amp\CancellationTokenSource;
+use Amp\Promise;
 use Docker\API\ClientAsync;
+use Docker\Client\AmpArtaxStreamEndpoint;
+use Docker\Client\ProvideAmpArtaxClientOptions;
+use Docker\Endpoint\SystemEvents;
+use Jane\OpenApiRuntime\Client\AmpArtaxEndpoint;
+use function Amp\call;
 
 /**
  * Docker\Docker.
@@ -18,5 +26,49 @@ class DockerAsync extends ClientAsync
         }
 
         return parent::create($httpClient);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function systemEvents(array $queryParameters = [], string $fetch = self::FETCH_OBJECT): Promise
+    {
+        return $this->executeArtaxEndpoint(new SystemEvents($queryParameters), $fetch);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function executeArtaxEndpoint(AmpArtaxEndpoint $endpoint, string $fetch = self::FETCH_OBJECT): Promise
+    {
+        return call(function () use ($endpoint, $fetch) {
+            [$bodyHeaders, $body] = $endpoint->getBody($this->serializer);
+            $queryString = $endpoint->getQueryString();
+            $uri = '' !== $queryString ? $endpoint->getUri().'?'.$queryString : $endpoint->getUri();
+            $request = new Request($uri, $endpoint->getMethod());
+            $request = $request->withBody($body);
+            $request = $request->withHeaders($endpoint->getHeaders($bodyHeaders));
+            $options = [];
+            if ($endpoint instanceof ProvideAmpArtaxClientOptions) {
+                $options = $endpoint->getAmpArtaxClientOptions();
+            }
+
+            if ($endpoint instanceof AmpArtaxStreamEndpoint) {
+                $cancellationTokenSource = new CancellationTokenSource();
+
+                return $endpoint->parseArtaxStreamResponse(
+                    yield $this->httpClient->request($request, $options, $cancellationTokenSource->getToken()),
+                    $this->serializer,
+                    $cancellationTokenSource,
+                    $fetch
+                );
+            }
+
+            return $endpoint->parseArtaxResponse(
+                yield $this->httpClient->request($request, $options),
+                $this->serializer,
+                $fetch
+            );
+        });
     }
 }

--- a/src/Endpoint/SystemEvents.php
+++ b/src/Endpoint/SystemEvents.php
@@ -4,15 +4,26 @@ declare(strict_types=1);
 
 namespace Docker\Endpoint;
 
+use Amp\Artax\Client as ArtaxClient;
 use Docker\API\Endpoint\SystemEvents as BaseEndpoint;
+use Docker\Client\AmpArtaxStreamEndpoint;
+use Docker\Client\AmpArtaxStreamEndpointTrait;
+use Docker\Client\ProvideAmpArtaxClientOptions;
 use Docker\Stream\EventStream;
 use Jane\OpenApiRuntime\Client\Client;
 use Jane\OpenApiRuntime\Client\Exception\InvalidFetchModeException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
-class SystemEvents extends BaseEndpoint
+class SystemEvents extends BaseEndpoint implements ProvideAmpArtaxClientOptions, AmpArtaxStreamEndpoint
 {
+    use AmpArtaxStreamEndpointTrait;
+
+    public function getAmpArtaxClientOptions(): array
+    {
+        return [ArtaxClient::OP_TRANSFER_TIMEOUT => 0];
+    }
+
     public function parsePSR7Response(ResponseInterface $response, SerializerInterface $serializer, string $fetchMode = Client::FETCH_OBJECT)
     {
         if (Client::FETCH_OBJECT === $fetchMode) {

--- a/src/Stream/ArtaxCallbackStream.php
+++ b/src/Stream/ArtaxCallbackStream.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Docker\Stream;
+
+use Amp\ByteStream\InputStream;
+use Amp\CancellationTokenSource;
+use Amp\Promise;
+use function Amp\call;
+
+class ArtaxCallbackStream
+{
+    private $stream;
+    private $onNewFrameCallables = [];
+    private $chunkTransformer;
+    private $cancellationTokenSource;
+
+    public function __construct(
+        InputStream $stream,
+        CancellationTokenSource $cancellationTokenSource,
+        ?callable $chunkTransformer
+    ) {
+        $this->stream = $stream;
+        $this->cancellationTokenSource = $cancellationTokenSource;
+        $this->chunkTransformer = $chunkTransformer;
+    }
+
+    /**
+     * Called when there is a new frame from the stream.
+     *
+     * @param callable $onNewFrame
+     */
+    public function onFrame(callable $onNewFrame): void
+    {
+        $this->onNewFrameCallables[] = $onNewFrame;
+    }
+
+    /**
+     * Consume stream chunks.
+     *
+     * @return Promise
+     */
+    public function listen(): Promise
+    {
+        return call(function () {
+            while (null !== ($chunk = yield $this->stream->read())) {
+                foreach ($this->onNewFrameCallables as $newFrameCallable) {
+                    $newFrameCallable($this->transformChunk($chunk));
+                }
+            }
+        });
+    }
+
+    /**
+     * Stop consuming stream chunks.
+     */
+    public function cancel(): void
+    {
+        $this->cancellationTokenSource->cancel();
+    }
+
+    /**
+     * Transform stream chunks if required.
+     *
+     * @param string $chunk
+     *
+     * @return mixed The raw chunk or the transformed chunk
+     */
+    private function transformChunk(string $chunk)
+    {
+        if (null === $this->chunkTransformer) {
+            return $chunk;
+        }
+
+        return \call_user_func($this->chunkTransformer, $chunk);
+    }
+}

--- a/tests/DockerAsyncTest.php
+++ b/tests/DockerAsyncTest.php
@@ -42,10 +42,8 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
         });
     }
 
-    /** @group sys */
     public function testSystemEventsAllowTheConsumptionOfDockerEvents(): void
     {
-        \putenv('AMP_DEBUG=1');
         $matchedEvents = [];
 
         Loop::run(function () use (&$matchedEvents) {
@@ -78,8 +76,8 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
 
             yield $docker->containerCreate($containerConfig);
 
-            Loop::delay(1000, function () use ($events): void {
-                $events->cancel();
+            Loop::delay(1000, function (): void {
+                Loop::stop();
             });
         });
 

--- a/tests/DockerAsyncTest.php
+++ b/tests/DockerAsyncTest.php
@@ -9,6 +9,7 @@ use Amp\Loop;
 use Docker\API\Model\ContainersCreatePostBody;
 use Docker\API\Model\EventsGetResponse200;
 use Docker\DockerAsync;
+use Docker\Stream\ArtaxCallbackStream;
 
 class DockerAsyncTest extends \PHPUnit\Framework\TestCase
 {
@@ -48,7 +49,7 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
             $docker = DockerAsync::create();
 
             $actualEvent = null;
-
+            /** @var ArtaxCallbackStream $events */
             $events = yield $docker->systemEvents();
             $events->onFrame(function ($event) use (&$actualEvent): void {
                 $actualEvent = $event;
@@ -62,7 +63,7 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
             $containerCreate = yield $docker->containerCreate($containerConfig);
 
             // Let a chance for the container create event to be dispatched to the consumer
-            yield new Delayed(100);
+            yield new Delayed(1000);
 
             $events->cancel();
 

--- a/tests/DockerAsyncTest.php
+++ b/tests/DockerAsyncTest.php
@@ -53,7 +53,7 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
             /** @var ArtaxCallbackStream $events */
             $events = yield $docker->systemEvents(
                 [
-                    'filters' => json_encode(['type' => ['container'], 'action' => ['create']])
+                    'filters' => \json_encode(['type' => ['container'], 'action' => ['create']]),
                 ]
             );
             $events->onFrame(function ($event) use (&$receivedEvents): void {
@@ -73,14 +73,14 @@ class DockerAsyncTest extends \PHPUnit\Framework\TestCase
 
             $events->cancel();
 
-            $matchedEvents = array_filter(
+            $matchedEvents = \array_filter(
                 $receivedEvents,
                 function ($event) use ($containerCreate) {
                     return \is_object($event)
                         && $event instanceof EventsGetResponse200
-                        && $event->getAction() === 'create'
-                        && $event->getType() === 'container'
-                        && $event->getActor() !== null
+                        && 'create' === $event->getAction()
+                        && 'container' === $event->getType()
+                        && null !== $event->getActor()
                         && $event->getActor()->getID() === $containerCreate->getId();
                 }
             );


### PR DESCRIPTION
This feature make it possible to consume docker system events asynchronously using the `DockerAsync` client implementation.

Fixes issue #312 

## How to use

```php
<?php

// filename : ./examples/listen-to-docker-events-async.php

use Docker\DockerAsync;
use Docker\Stream\ArtaxCallbackStream;

require dirname(__DIR__) . '/vendor/autoload.php';

Amp\Loop::run(function () {
    $docker = DockerAsync::create();

    /** @var ArtaxCallbackStream $events */
    $events = yield $docker->systemEvents();
    $events->onFrame(function ($event): void {
        // Do something with the docker event
        // var_dump($event);
    });

    // Start listening to Docker events
    $events->listen();

    // Close the request when a SIGINT signal is received
    Amp\Loop::onSignal(SIGINT, function (string $watcherId) use ($events) {
        $events->cancel();
        Amp\Loop::cancel($watcherId);
    });
});

```

