### PR TITLE
Fix PHPUnit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "amphp/artax": "To use the async api"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "friendsofphp/php-cs-fixer": "2.8.1",
         "amphp/artax": "^3.0",
         "amphp/socket": "^0.10.5"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>


### PR DESCRIPTION
# Changed log
- Fix PHPUnit version definition.
- The PHPUnit `^7.0` version requires the `php-7.1` at least.
- Remove the invalid `syntaxcheck` attribute in `phpunit.xml.dist` file.